### PR TITLE
Update README.md Colab link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Pre-release development of high-level probabilistic programming interface for Te
 
 For a full list of code contributors based on code checkin activity, see the [GitHub contributor page](https://github.com/pymc-devs/pymc4/graphs/contributors).
 
-As PyMC4 builds upon TensorFlow, particularly the TensorFlow Probability and Edward2 modules, its design is heavily influenced by innovations introduced in these packages. In particular, early development was partially derived from a [prototype](https://colab.research.google.com/drive/15Vth0taPoTL3JmL_tw1J2IYM22ufP_1m#scrollTo=-Kcs3_9TL4bh) written by Josh Safyan.
+As PyMC4 builds upon TensorFlow, particularly the TensorFlow Probability and Edward2 modules, its design is heavily influenced by innovations introduced in these packages. In particular, early development was partially derived from a [prototype](https://github.com/tensorflow/probability/blob/9c2a4c8bbeddebded2b998027ec7111dcdfd9070/discussion/higher_level_modeling_api_demo.ipynb) written by Josh Safyan.
 
 ## License
 


### PR DESCRIPTION
This change updates the link to point to the copy of the Colab at the TensorFlow Probability repository.

Thanks very much for adding this.