### PR TITLE
CI use pipenv as virtualenv and package manage tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ ENV/
 
 # VSCode
 .vscode/
+
+# Pycharm
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,20 @@
+sudo: false
+
 language: python
 
 python:
   - "3.6"
 
+# command to install dependencies
 install:
-  - sudo apt-get update
-  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
-  - conda info -a
-
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
-  - source activate test-environment
-  - pip install .
-  - pip install -r requirements-dev.txt
-  - pip install coveralls
+  - pip install pipenv coveralls
+  - pipenv install --skip-lock
+  - pipenv install --dev --skip-lock
 
 script:
-  - python -m pylint pymc4/
-  - python -m pytest -xv --cov=pymc4/ tests/
-  - pycodestyle --show-source --show-pep8 pymc4/ tests/
+  - pipenv run python -m pylint pymc4/
+  - pipenv run python -m pytest -xv --cov=pymc4/ tests/
+  - pipenv run pycodestyle --show-source --show-pep8 pymc4/ tests/
 
 
 after_success:

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,23 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+xarray = "*"
+numpy = "*"
+tqdm = "*"
+biwrap = "*"
+tf-nightly = "*"
+tfp-nightly = "*"
+tb-nightly = "*"
+
+[dev-packages]
+pylint = "*"
+pytest = "*"
+pytest-cov = "*"
+"pytest-pep8" = "*"
+pycodestyle = "*"
+
+[requires]
+python_version = "3.6"


### PR DESCRIPTION
Install miniconda for each test not a good idea, It spend a lot of time, `pipenv` is a better tool to manage virtualenv and package. 
And use `pipenv` install package to avoid forgetting to write the package information into the `requirements.txt` or `requirements-dev.txt` file.