### PR TITLE
Specified the latest versions of tf/tfp/tfb-nightly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ xarray==0.10.4
 numpy==1.14.3
 tqdm==4.23.3
 biwrap
-tf-nightly==1.9.0.dev20180607
-tfp-nightly==0.3.0.dev20180725
-tb-nightly==1.9.0a20180613
+tf-nightly
+tfp-nightly
+tb-nightly


### PR DESCRIPTION
This PR solves this "Installation fails" issue, https://github.com/pymc-devs/pymc4/issues/23, by specifying the latest versions of `tf/tfp/tfb-nightly` packages.