### PR TITLE
Edit readme: followed changes in arviz's APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ trace = pm.sample(model)
 # See https://github.com/arviz-devs/arviz
 # pip install git+git://github.com/arviz-devs/arviz.git
 import arviz as az
+%matplotlib inline
 
-posterior_data = az.convert_to_xarray(trace, chains=1)
-az.posteriorplot(posterior_data, figsize=(8, 4), textsize=15, round_to=2);
+posterior_data = az.convert_to_dataset(trace)
+az.plot_posterior(posterior_data, figsize=(8, 4), textsize=15, round_to=2)
 ```
 
 


### PR DESCRIPTION
The arviz APIs have been changed, and I edited the visualization part in the README.

- convert_to_xarray => convert_to_dataset (I'm not sure if these APIs are equivelant, are they?)
- posteriorplot  => plot_posterior

The below is the output: 

![arviz](https://user-images.githubusercontent.com/1390726/46470009-21fc1280-c810-11e8-9fa9-714abe016c14.png)

