### PR TITLE
ENH: add more random variables

### DIFF
--- a/pymc4/_random_variables.py
+++ b/pymc4/_random_variables.py
@@ -12,8 +12,8 @@ import tensorflow_probability as tfp
 from tensorflow_probability import distributions as tfd
 
 
-# Random variables that PyMC3 supports, but tfp does not support as
-# distributions. We implement these random variables.
+# Random variables tfp does not support as distributions. We implement these
+# random variables.
 tfp_unsupported = [
     "Constant",
     "DiscreteUniform",
@@ -25,9 +25,9 @@ tfp_unsupported = [
     "ZeroInflatedPoisson",
 ]
 
-# Random variables that PyMC3 supports, that tfp also support as distributions.
-# We wrap these distributions as random variables. Names must match
-# tfp.distributions names exactly.
+# Random variables that tfp supports as distributions. We wrap these
+# distributions as random variables. Names must match tfp.distributions names
+# exactly.
 tfp_supported = [
     "Bernoulli",
     "Beta",

--- a/pymc4/_random_variables.py
+++ b/pymc4/_random_variables.py
@@ -212,7 +212,7 @@ class Constant(RandomVariable):
 
 
 class DiscreteUniform(RandomVariable):
-    def __dist(*args, **kwargs):
+    def _base_dist(*args, **kwargs):
         probs = np.ones(high - low) / (high - low)
         return tfd.TransformedDistribution(
             distribution=tfd.Categorical(probs=probs),
@@ -220,83 +220,69 @@ class DiscreteUniform(RandomVariable):
             name="DiscreteUniform",
         )
 
-    _base_dist = __dist
-
 
 class HalfStudentT(RandomVariable):
     # A HalfStudentT is the absolute value of a StudentT.
-    def __dist(*args, **kwargs):
+    def _base_dist(*args, **kwargs):
         return tfd.TransformedDistribution(
             distribution=tfd.StudentT(*args, **kwargs),
             bijector=tfp.bijectors.AbsoluteValue(),
             name="HalfStudentT",
         )
 
-    _base_dist = __dist
-
 
 class LogitNormal(RandomVariable):
     # A LogitNormal is the standard logistic of a Normal.
-    def __dist(*args, **kwargs):
+    def _base_dist(*args, **kwargs):
         return tfd.TransformedDistribution(
             distribution=tfd.Normal(*args, **kwargs),
             bijector=tfp.bijectors.Sigmoid(),
             name="LogitNormal",
         )
 
-    _base_dist = __dist
-
 
 class Weibull(RandomVariable):
     # The inverse of the Weibull bijector applied to a U[0, 1] random variable
     # gives a Weibull-distributed random variable.
-    def __dist(*args, **kwargs):
+    def _base_dist(*args, **kwargs):
         return tfd.TransformedDistribution(
             distribution=tfd.Uniform(0.0, 1.0),
             bijector=tfp.bijectors.Invert(tfp.bijectors.Weibull(*args, **kwargs)),
             name="Weibull",
         )
 
-    _base_dist = __dist
-
 
 class ZeroInflatedBinomial(RandomVariable):
     # A ZeroInflatedBinomial is a mixture between a deterministic distribution
     # and a Binomial distribution.
-    def __dist(mix, *args, **kwargs):
+    def _base_dist(mix, *args, **kwargs):
         return tfd.Mixture(
             cat=tfd.Categorical(probs=[mix, 1.0 - mix]),
             components=[tfd.Deterministic(0.0), tfd.Binomial(*args, **kwargs)],
             name="ZeroInflatedBinomial",
         )
 
-    _base_dist = __dist
-
 
 class ZeroInflatedPoisson(RandomVariable):
     # A ZeroInflatedPoisson is a mixture between a deterministic distribution
     # and a Poisson distribution.
-    def __dist(mix, *args, **kwargs):
+    def _base_dist(mix, *args, **kwargs):
         return tfd.Mixture(
             cat=tfd.Categorical(probs=[mix, 1.0 - mix]),
             components=[tfd.Deterministic(0.0), tfd.Poisson(*args, **kwargs)],
             name="ZeroInflatedPoisson",
         )
 
-    _base_dist = __dist
-
 
 class ZeroInflatedNegativeBinomial(RandomVariable):
     # A ZeroInflatedNegativeBinomial is a mixture between a deterministic
     # distribution and a NegativeBinomial distribution.
-    def __dist(mix, *args, **kwargs):
+    def _base_dist(mix, *args, **kwargs):
         return tfd.Mixture(
             cat=tfd.Categorical(probs=[mix, 1.0 - mix]),
             components=[tfd.Deterministic(0.0), tfd.NegativeBinomial(*args, **kwargs)],
             name="ZeroInflatedNegativeBinomial",
         )
-
-    _base_dist = __dist
 
 
 # Programmatically wrap tfp.distribtions into pm.RandomVariables

--- a/pymc4/_random_variables.py
+++ b/pymc4/_random_variables.py
@@ -217,7 +217,7 @@ class DiscreteUniform(RandomVariable):
         kwargs.update({"low": low, "high": high})
         super(DiscreteUniform, self).__init__(name, *args, **kwargs)
 
-    def _base_dist(*args, **kwargs):
+    def _base_dist(self, *args, **kwargs):
         """A DiscreteUniform is an equiprobable Categorical over (high-low),
         shifted up by low."""
         low = kwargs.pop("low")
@@ -231,7 +231,7 @@ class DiscreteUniform(RandomVariable):
 
 
 class HalfStudentT(RandomVariable):
-    def _base_dist(*args, **kwargs):
+    def _base_dist(self, *args, **kwargs):
         """A HalfStudentT is the absolute value of a StudentT."""
         return tfd.TransformedDistribution(
             distribution=tfd.StudentT(*args, **kwargs),
@@ -241,7 +241,7 @@ class HalfStudentT(RandomVariable):
 
 
 class LogitNormal(RandomVariable):
-    def _base_dist(*args, **kwargs):
+    def _base_dist(self, *args, **kwargs):
         """A LogitNormal is the standard logistic of a Normal."""
         return tfd.TransformedDistribution(
             distribution=tfd.Normal(*args, **kwargs),
@@ -251,7 +251,7 @@ class LogitNormal(RandomVariable):
 
 
 class Weibull(RandomVariable):
-    def _base_dist(*args, **kwargs):
+    def _base_dist(self, *args, **kwargs):
         """The inverse of the Weibull bijector applied to a U[0, 1] random
         variable gives a Weibull-distributed random variable."""
         return tfd.TransformedDistribution(
@@ -267,7 +267,7 @@ class ZeroInflatedBinomial(RandomVariable):
         kwargs.update({"mix": mix})
         super(ZeroInflatedBinomial, self).__init__(name, *args, **kwargs)
 
-    def _base_dist(*args, **kwargs):
+    def _base_dist(self, *args, **kwargs):
         """A ZeroInflatedBinomial is a mixture between a deterministic
         distribution and a Binomial distribution."""
         mix = kwargs.pop("mix")
@@ -284,7 +284,7 @@ class ZeroInflatedPoisson(RandomVariable):
         kwargs.update({"mix": mix})
         super(ZeroInflatedPoisson, self).__init__(name, *args, **kwargs)
 
-    def _base_dist(*args, **kwargs):
+    def _base_dist(self, *args, **kwargs):
         """A ZeroInflatedPoisson is a mixture between a deterministic
         distribution and a Poisson distribution."""
         mix = kwargs.pop("mix")
@@ -301,7 +301,7 @@ class ZeroInflatedNegativeBinomial(RandomVariable):
         kwargs.update({"mix": mix})
         super(ZeroInflatedNegativeBinomial, self).__init__(name, *args, **kwargs)
 
-    def _base_dist(*args, **kwargs):
+    def _base_dist(self, *args, **kwargs):
         """A ZeroInflatedNegativeBinomial is a mixture between a deterministic
         distribution and a NegativeBinomial distribution."""
         mix = kwargs.pop("mix")

--- a/pymc4/_random_variables.py
+++ b/pymc4/_random_variables.py
@@ -9,7 +9,7 @@ from . import _template_contexts as contexts
 import sys
 import numpy as np
 import tensorflow_probability as tfp
-import tensorflow_probability.distributions as tfd
+from tensorflow_probability import distributions as tfd
 
 
 # Random variables that PyMC4 support, but tfp does not support as
@@ -212,7 +212,7 @@ class Constant(RandomVariable):
 
 
 class DiscreteUniform(RandomVariable):
-    def __dist(low, high, *args, **kwargs):
+    def __dist(*args, **kwargs):
         probs = np.ones(high - low) / (high - low)
         return tfd.TransformedDistribution(
             distribution=tfd.Categorical(probs=probs),

--- a/pymc4/_random_variables.py
+++ b/pymc4/_random_variables.py
@@ -12,7 +12,7 @@ import tensorflow_probability as tfp
 from tensorflow_probability import distributions as tfd
 
 
-# Random variables that PyMC4 support, but tfp does not support as
+# Random variables that PyMC3 support, but tfp does not support as
 # distributions. We implement these random variables.
 tfp_unsupported = [
     "Constant",
@@ -25,7 +25,7 @@ tfp_unsupported = [
     "ZeroInflatedPoisson",
 ]
 
-# Random variables that PyMC4 support, that tfp also support as distributions.
+# Random variables that PyMC3 support, that tfp also support as distributions.
 # We wrap these distributions as random variables. Names must match
 # tfp.distributions names exactly.
 tfp_supported = [

--- a/pymc4/_random_variables.py
+++ b/pymc4/_random_variables.py
@@ -12,7 +12,7 @@ import tensorflow_probability as tfp
 from tensorflow_probability import distributions as tfd
 
 
-# Random variables that PyMC3 support, but tfp does not support as
+# Random variables that PyMC3 supports, but tfp does not support as
 # distributions. We implement these random variables.
 tfp_unsupported = [
     "Constant",
@@ -25,7 +25,7 @@ tfp_unsupported = [
     "ZeroInflatedPoisson",
 ]
 
-# Random variables that PyMC3 support, that tfp also support as distributions.
+# Random variables that PyMC3 supports, that tfp also support as distributions.
 # We wrap these distributions as random variables. Names must match
 # tfp.distributions names exactly.
 tfp_supported = [

--- a/pymc4/_random_variables.py
+++ b/pymc4/_random_variables.py
@@ -212,7 +212,16 @@ class Constant(RandomVariable):
 
 
 class DiscreteUniform(RandomVariable):
+    def __init__(self, name, low, high, *args, **kwargs):
+        """Add `low` and `high` to kwargs."""
+        kwargs.update({"low": low, "high": high})
+        super(DiscreteUniform, self).__init__(name, *args, **kwargs)
+
     def _base_dist(*args, **kwargs):
+        """A DiscreteUniform is an equiprobable Categorical over (high-low),
+        shifted up by low."""
+        low = kwargs["low"]
+        high = kwargs["high"]
         probs = np.ones(high - low) / (high - low)
         return tfd.TransformedDistribution(
             distribution=tfd.Categorical(probs=probs),
@@ -222,8 +231,8 @@ class DiscreteUniform(RandomVariable):
 
 
 class HalfStudentT(RandomVariable):
-    # A HalfStudentT is the absolute value of a StudentT.
     def _base_dist(*args, **kwargs):
+        """A HalfStudentT is the absolute value of a StudentT."""
         return tfd.TransformedDistribution(
             distribution=tfd.StudentT(*args, **kwargs),
             bijector=tfp.bijectors.AbsoluteValue(),
@@ -232,8 +241,8 @@ class HalfStudentT(RandomVariable):
 
 
 class LogitNormal(RandomVariable):
-    # A LogitNormal is the standard logistic of a Normal.
     def _base_dist(*args, **kwargs):
+        """A LogitNormal is the standard logistic of a Normal."""
         return tfd.TransformedDistribution(
             distribution=tfd.Normal(*args, **kwargs),
             bijector=tfp.bijectors.Sigmoid(),
@@ -242,20 +251,26 @@ class LogitNormal(RandomVariable):
 
 
 class Weibull(RandomVariable):
-    # The inverse of the Weibull bijector applied to a U[0, 1] random variable
-    # gives a Weibull-distributed random variable.
     def _base_dist(*args, **kwargs):
+        """The inverse of the Weibull bijector applied to a U[0, 1] random
+        variable gives a Weibull-distributed random variable."""
         return tfd.TransformedDistribution(
-            distribution=tfd.Uniform(0.0, 1.0),
+            distribution=tfd.Uniform(low=0.0, high=1.0),
             bijector=tfp.bijectors.Invert(tfp.bijectors.Weibull(*args, **kwargs)),
             name="Weibull",
         )
 
 
 class ZeroInflatedBinomial(RandomVariable):
-    # A ZeroInflatedBinomial is a mixture between a deterministic distribution
-    # and a Binomial distribution.
-    def _base_dist(mix, *args, **kwargs):
+    def __init__(self, name, mix, *args, **kwargs):
+        """Add `mix` to kwargs."""
+        kwargs.update({"mix": mix})
+        super(ZeroInflatedBinomial, self).__init__(name, *args, **kwargs)
+
+    def _base_dist(*args, **kwargs):
+        """A ZeroInflatedBinomial is a mixture between a deterministic
+        distribution and a Binomial distribution."""
+        mix = kwargs["mix"]
         return tfd.Mixture(
             cat=tfd.Categorical(probs=[mix, 1.0 - mix]),
             components=[tfd.Deterministic(0.0), tfd.Binomial(*args, **kwargs)],
@@ -264,9 +279,15 @@ class ZeroInflatedBinomial(RandomVariable):
 
 
 class ZeroInflatedPoisson(RandomVariable):
-    # A ZeroInflatedPoisson is a mixture between a deterministic distribution
-    # and a Poisson distribution.
-    def _base_dist(mix, *args, **kwargs):
+    def __init__(self, name, mix, *args, **kwargs):
+        """Add `mix` to kwargs."""
+        kwargs.update({"mix": mix})
+        super(ZeroInflatedPoisson, self).__init__(name, *args, **kwargs)
+
+    def _base_dist(*args, **kwargs):
+        """A ZeroInflatedPoisson is a mixture between a deterministic
+        distribution and a Poisson distribution."""
+        mix = kwargs["mix"]
         return tfd.Mixture(
             cat=tfd.Categorical(probs=[mix, 1.0 - mix]),
             components=[tfd.Deterministic(0.0), tfd.Poisson(*args, **kwargs)],
@@ -275,9 +296,15 @@ class ZeroInflatedPoisson(RandomVariable):
 
 
 class ZeroInflatedNegativeBinomial(RandomVariable):
-    # A ZeroInflatedNegativeBinomial is a mixture between a deterministic
-    # distribution and a NegativeBinomial distribution.
-    def _base_dist(mix, *args, **kwargs):
+    def __init__(self, name, mix, *args, **kwargs):
+        """Add `mix` to kwargs."""
+        kwargs.update({"mix": mix})
+        super(ZeroInflatedNegativeBinomial, self).__init__(name, *args, **kwargs)
+
+    def _base_dist(*args, **kwargs):
+        """A ZeroInflatedNegativeBinomial is a mixture between a deterministic
+        distribution and a NegativeBinomial distribution."""
+        mix = kwargs["mix"]
         return tfd.Mixture(
             cat=tfd.Categorical(probs=[mix, 1.0 - mix]),
             components=[tfd.Deterministic(0.0), tfd.NegativeBinomial(*args, **kwargs)],

--- a/pymc4/_random_variables.py
+++ b/pymc4/_random_variables.py
@@ -220,8 +220,8 @@ class DiscreteUniform(RandomVariable):
     def _base_dist(*args, **kwargs):
         """A DiscreteUniform is an equiprobable Categorical over (high-low),
         shifted up by low."""
-        low = kwargs["low"]
-        high = kwargs["high"]
+        low = kwargs.pop("low")
+        high = kwargs.pop("high")
         probs = np.ones(high - low) / (high - low)
         return tfd.TransformedDistribution(
             distribution=tfd.Categorical(probs=probs),
@@ -270,7 +270,7 @@ class ZeroInflatedBinomial(RandomVariable):
     def _base_dist(*args, **kwargs):
         """A ZeroInflatedBinomial is a mixture between a deterministic
         distribution and a Binomial distribution."""
-        mix = kwargs["mix"]
+        mix = kwargs.pop("mix")
         return tfd.Mixture(
             cat=tfd.Categorical(probs=[mix, 1.0 - mix]),
             components=[tfd.Deterministic(0.0), tfd.Binomial(*args, **kwargs)],
@@ -287,7 +287,7 @@ class ZeroInflatedPoisson(RandomVariable):
     def _base_dist(*args, **kwargs):
         """A ZeroInflatedPoisson is a mixture between a deterministic
         distribution and a Poisson distribution."""
-        mix = kwargs["mix"]
+        mix = kwargs.pop("mix")
         return tfd.Mixture(
             cat=tfd.Categorical(probs=[mix, 1.0 - mix]),
             components=[tfd.Deterministic(0.0), tfd.Poisson(*args, **kwargs)],
@@ -304,7 +304,7 @@ class ZeroInflatedNegativeBinomial(RandomVariable):
     def _base_dist(*args, **kwargs):
         """A ZeroInflatedNegativeBinomial is a mixture between a deterministic
         distribution and a NegativeBinomial distribution."""
-        mix = kwargs["mix"]
+        mix = kwargs.pop("mix")
         return tfd.Mixture(
             cat=tfd.Categorical(probs=[mix, 1.0 - mix]),
             components=[tfd.Deterministic(0.0), tfd.NegativeBinomial(*args, **kwargs)],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-tf-nightly-2.0-preview
+tf-nightly
 tfp-nightly


### PR DESCRIPTION
First attempt at #44. Not ready for review yet. This PR should wait until after #41 is merged.

Briefly, there are two kinds of random variables: 1) those that are supported as tfp distributions, and 2) those that are not. Type 1 is easily wrapped as RVs. A good number of type 2 can be achieved by `tfd.TransformedDistribution`, `tfd.Bijector` and `tfd.Mixture`. I hope that this PR will merge in all the distributions that PyMC3 currently supports, that can also be made from mixtures or bijectors of type 1 distributions. This will leave us with the trickier distributions to implement later (e.g. SkewNormal).

Some other notes:
- There should be a restructuring PR following this to split out all this code into several files.
- This PR renames PyMC3's `Wald` to tfp's `InverseGaussian`