### PR TITLE
TST: test all rvs, not just tfp supported distributions

### DIFF
--- a/pymc4/_random_variables.py
+++ b/pymc4/_random_variables.py
@@ -10,7 +10,6 @@ Implements random variables not supported by tfp as distributions.
 from . import _template_contexts as contexts
 
 import sys
-import numpy as np
 import tensorflow_probability as tfp
 from tensorflow_probability import distributions as tfd
 

--- a/pymc4/_random_variables.py
+++ b/pymc4/_random_variables.py
@@ -18,6 +18,7 @@ from tensorflow_probability import distributions as tfd
 # random variables.
 tfp_unsupported = [
     "Constant",
+    # TODO DiscreteUniform raises a NotImplementedError from tfp.
     # "DiscreteUniform",
     "HalfStudentT",
     "LogitNormal",
@@ -211,7 +212,7 @@ class Constant(RandomVariable):
     _base_dist = tfd.Deterministic
 
 
-'''
+''' TODO DiscreteUniform raises a NotImplementedError from tfp.
 class DiscreteUniform(RandomVariable):
     def __init__(self, name, low, high, *args, **kwargs):
         """Add `low` and `high` to kwargs."""

--- a/pymc4/_random_variables.py
+++ b/pymc4/_random_variables.py
@@ -19,7 +19,7 @@ from tensorflow_probability import distributions as tfd
 # random variables.
 tfp_unsupported = [
     "Constant",
-    "DiscreteUniform",
+    # "DiscreteUniform",
     "HalfStudentT",
     "LogitNormal",
     "Weibull",
@@ -212,6 +212,7 @@ class Constant(RandomVariable):
     _base_dist = tfd.Deterministic
 
 
+'''
 class DiscreteUniform(RandomVariable):
     def __init__(self, name, low, high, *args, **kwargs):
         """Add `low` and `high` to kwargs."""
@@ -233,6 +234,7 @@ class DiscreteUniform(RandomVariable):
             bijector=tfp.bijectors.AffineScalar(shift=low),
             name="DiscreteUniform",
         )
+'''
 
 
 class HalfStudentT(RandomVariable):

--- a/pymc4/tests/test_random_variables.py
+++ b/pymc4/tests/test_random_variables.py
@@ -16,6 +16,7 @@ def random_variable_args():
         (_random_variables.Chi2, {"df": 2}),
         (_random_variables.Constant, {"loc": 3}),
         (_random_variables.Dirichlet, {"concentration": [1, 2], "sample": [0.5, 0.5]}),
+        # TODO DiscreteUniform raises a NotImplementedError from tfp.
         # (_random_variables.DiscreteUniform, {"low": 2, "high": 10, "sample": 5}),
         (_random_variables.Exponential, {"rate": 1}),
         (_random_variables.Gamma, {"concentration": 3.0, "rate": 2.0}),

--- a/pymc4/tests/test_random_variables.py
+++ b/pymc4/tests/test_random_variables.py
@@ -81,7 +81,7 @@ def test_rvs_logp_and_forward_sample(tf_session, randomvariable, kwargs):
     sample = kwargs.pop("sample", 0.1)
     dist = randomvariable("test_dist", **kwargs, validate_args=True)
 
-    if randomvariable.__name__ != "Binomial":
+    if randomvariable.__name__ not in ["Binomial", "ZeroInflatedBinomial"]:
         # Assert that values are returned with no exceptions
         log_prob = dist.log_prob()
         vals = tf_session.run([log_prob], feed_dict={dist._backend_tensor: sample})
@@ -89,7 +89,7 @@ def test_rvs_logp_and_forward_sample(tf_session, randomvariable, kwargs):
 
     else:
         # TFP issue ticket for Binom.sample_n https://github.com/tensorflow/probability/issues/81
-        assert randomvariable.__name__ == "Binomial"
+        assert randomvariable.__name__ in ["Binomial", "ZeroInflatedBinomial]
         with pytest.raises(NotImplementedError) as err:
             dist.log_prob()
             assert "NotImplementedError: sample_n is not implemented: Binomial" == str(err)

--- a/pymc4/tests/test_random_variables.py
+++ b/pymc4/tests/test_random_variables.py
@@ -2,7 +2,6 @@
 Tests for PyMC4 random variables
 """
 import pytest
-import numpy as np
 from .. import _random_variables
 
 

--- a/pymc4/tests/test_random_variables.py
+++ b/pymc4/tests/test_random_variables.py
@@ -17,7 +17,7 @@ def random_variable_args():
         (_random_variables.Chi2, {"df": 2}),
         (_random_variables.Constant, {"loc": 3}),
         (_random_variables.Dirichlet, {"concentration": [1, 2], "sample": [0.5, 0.5]}),
-        (_random_variables.DiscreteUniform, {"low": 2, "high": 10}),
+        # (_random_variables.DiscreteUniform, {"low": 2, "high": 10}),
         (_random_variables.Exponential, {"rate": 1}),
         (_random_variables.Gamma, {"concentration": 3.0, "rate": 2.0}),
         (_random_variables.Geometric, {"probs": 0.5, "sample": 10}),
@@ -53,11 +53,11 @@ def random_variable_args():
         (_random_variables.Wishart, {"df": 3, "scale_tril": [[1]], "sample": [[1]]}),
         (
             _random_variables.ZeroInflatedBinomial,
-            {"mix": 0.2, "total_count": 10, "probs": np.ones(5) / 5},
+            {"mix": 0.2, "total_count": 10, "probs": 0.5},
         ),
         (
             _random_variables.ZeroInflatedNegativeBinomial,
-            {"mix": 0.2, "total_count": 10, "probs": np.ones(5) / 5},
+            {"mix": 0.2, "total_count": 10, "probs": 0.5},
         ),
         (_random_variables.ZeroInflatedPoisson, {"mix": 0.2, "rate": 2}),
     )

--- a/pymc4/tests/test_random_variables.py
+++ b/pymc4/tests/test_random_variables.py
@@ -88,7 +88,7 @@ def test_rvs_logp_and_forward_sample(tf_session, randomvariable, kwargs):
 
     else:
         # TFP issue ticket for Binom.sample_n https://github.com/tensorflow/probability/issues/81
-        assert randomvariable.__name__ in ["Binomial", "ZeroInflatedBinomial]
+        assert randomvariable.__name__ in ["Binomial", "ZeroInflatedBinomial"]
         with pytest.raises(NotImplementedError) as err:
             dist.log_prob()
             assert "NotImplementedError: sample_n is not implemented: Binomial" == str(err)

--- a/pymc4/tests/test_random_variables.py
+++ b/pymc4/tests/test_random_variables.py
@@ -2,25 +2,29 @@
 Tests for PyMC4 random variables
 """
 import pytest
+import numpy as np
 from .. import _random_variables
 
 
-def tfp_supported_args():
-    """Provide arguments for each supported Tensorflow distribution"""
-    _tfp_supported_args = (
+def random_variable_args():
+    """Provide arguments for each random variable."""
+    _random_variable_args = (
         (_random_variables.Bernoulli, {"probs": 0.5}),
         (_random_variables.Beta, {"concentration0": 1, "concentration1": 1}),
         (_random_variables.Binomial, {"total_count": 5.0, "probs": 0.5, "sample": 1}),
         (_random_variables.Categorical, {"probs": [0.1, 0.5, 0.4]}),
         (_random_variables.Cauchy, {"loc": 0, "scale": 1}),
         (_random_variables.Chi2, {"df": 2}),
+        (_random_variables.Constant, {"loc": 3}),
         (_random_variables.Dirichlet, {"concentration": [1, 2], "sample": [0.5, 0.5]}),
+        (_random_variables.DiscreteUniform, {"low": 2, "high": 10}),
         (_random_variables.Exponential, {"rate": 1}),
         (_random_variables.Gamma, {"concentration": 3.0, "rate": 2.0}),
         (_random_variables.Geometric, {"probs": 0.5, "sample": 10}),
         (_random_variables.Gumbel, {"loc": 0, "scale": 1}),
         (_random_variables.HalfCauchy, {"loc": 0, "scale": 1}),
         (_random_variables.HalfNormal, {"scale": 3.0}),
+        (_random_variables.HalfStudentT, {"loc": 0, "scale": 1, "df": 10}),
         (_random_variables.InverseGamma, {"concentration": 3, "rate": 2}),
         (_random_variables.InverseGaussian, {"loc": 1, "concentration": 1}),
         (_random_variables.Kumaraswamy, {"concentration0": 0.5, "concentration1": 0.5}),
@@ -32,6 +36,7 @@ def tfp_supported_args():
             _random_variables.Multinomial,
             {"total_count": 4, "probs": [0.2, 0.3, 0.5], "sample": [1, 1, 2]},
         ),
+        (_random_variables.LogitNormal, {"loc": 0, "scale": 1}),
         (
             _random_variables.MultivariateNormalFullCovariance,
             {"loc": [1, 2], "covariance_matrix": [[0.36, 0.12], [0.12, 0.36]], "sample": [1, 2]},
@@ -44,11 +49,25 @@ def tfp_supported_args():
         (_random_variables.Triangular, {"low": 0.0, "high": 1.0, "peak": 0.5}),
         (_random_variables.Uniform, {"low": 0, "high": 1}),
         (_random_variables.VonMises, {"loc": 0, "concentration": 1}),
+        (_random_variables.Weibull, {"scale": 0.1, "concentration": 1}),
         (_random_variables.Wishart, {"df": 3, "scale_tril": [[1]], "sample": [[1]]}),
+        (
+            _random_variables.ZeroInflatedBinomial,
+            {"mix": 0.2, "total_count": 10, "probs": np.ones(5) / 5},
+        ),
+        (
+            _random_variables.ZeroInflatedNegativeBinomial,
+            {"mix": 0.2, "total_count": 10, "probs": np.ones(5) / 5},
+        ),
+        (_random_variables.ZeroInflatedPoisson, {"mix": 0.2, "rate": 2}),
     )
 
-    ids = [dist[0].__name__ for dist in _tfp_supported_args]
-    return {"argnames": ("randomvariable", "kwargs"), "argvalues": _tfp_supported_args, "ids": ids}
+    ids = [dist[0].__name__ for dist in _random_variable_args]
+    return {
+        "argnames": ("randomvariable", "kwargs"),
+        "argvalues": _random_variable_args,
+        "ids": ids,
+    }
 
 
 def test_tf_session_cleared(tf_session):
@@ -56,9 +75,9 @@ def test_tf_session_cleared(tf_session):
     assert len(tf_session.graph.get_operations()) == 0
 
 
-@pytest.mark.parametrize(**tfp_supported_args())
+@pytest.mark.parametrize(**random_variable_args())
 def test_rvs_logp_and_forward_sample(tf_session, randomvariable, kwargs):
-    """Test all RandomVariables that are implemented with TFP distributions"""
+    """Test forward sampling and evaluating the logp for all random variables."""
     sample = kwargs.pop("sample", 0.1)
     dist = randomvariable("test_dist", **kwargs, validate_args=True)
 


### PR DESCRIPTION
Closes #52 

Building off of #49, this PR adds tests for all current distributions, not just those supported by tfp.