### PR TITLE
DOC: numpy-style docstrings

### DIFF
--- a/pymc4/__init__.py
+++ b/pymc4/__init__.py
@@ -1,4 +1,4 @@
-"""PyMC4"""
+"""PyMC4."""
 from ._model import *
 from ._random_variables import *
 

--- a/pymc4/_hmc/quadpotential.py
+++ b/pymc4/_hmc/quadpotential.py
@@ -476,7 +476,7 @@ class QuadPotentialFull(QuadPotential):
 
 
 def add_ADATv(A, v, out, diag=None, beta=0.0, work=None):
-    """Run out = beta * out + A @ np.diag(D) @ A.T @ v"""
+    """Run out = beta * out + A @ np.diag(D) @ A.T @ v."""
     if work is None:
         work = np.empty(A.shape[1])
     linalg.blas.dgemv(1.0, A, v, y=work, trans=1, beta=0.0, overwrite_y=True)

--- a/pymc4/_hmc/trajectory.py
+++ b/pymc4/_hmc/trajectory.py
@@ -180,7 +180,6 @@ def leapfrog(H, q, p, epsilon, n_steps):
     momentum : Theano.tensor
         momentum estimate at time :math:`n \cdot e`.
     """
-
     def full_update(p, q):
         p = p + epsilon * H.dlogp(q)
         q += epsilon * H.pot.velocity(p)

--- a/pymc4/_hmc/trajectory.py
+++ b/pymc4/_hmc/trajectory.py
@@ -180,6 +180,7 @@ def leapfrog(H, q, p, epsilon, n_steps):
     momentum : Theano.tensor
         momentum estimate at time :math:`n \cdot e`.
     """
+
     def full_update(p, q):
         p = p + epsilon * H.dlogp(q)
         q += epsilon * H.pot.velocity(p)

--- a/pymc4/_model.py
+++ b/pymc4/_model.py
@@ -9,7 +9,7 @@ __all__ = ["model"]
 
 def model(func):
     """
-    Decorator function to wrap a model-specification function as a PyMC4 model.
+    Decorate a model-specification function as a PyMC4 model.
 
     Parameters
     ----------
@@ -35,9 +35,7 @@ class ModelTemplate:
         self._func = func
 
     def configure(self, *args, **kwargs):
-        """
-        This class method configures the model by setting it up as a Model object.
-        """
+        """Configure the model by setting it up as a Model object."""
         with contexts.ForwardContext() as context:
             model = Model(self, context, template_args=(args, kwargs))
             model._evaluate()
@@ -45,9 +43,7 @@ class ModelTemplate:
 
 
 class Model:
-    """
-    Base model object.
-    """
+    """Base model object."""
 
     def __init__(self, template, forward_context, template_args):
         self._template = template
@@ -63,7 +59,6 @@ class Model:
 
     def make_log_prob_function(self):
         """Return the log probability of the model."""
-
         def log_prob(*args):
             context = contexts.InferenceContext(args, expected_vars=self._forward_context.vars)
             with context:

--- a/pymc4/_model.py
+++ b/pymc4/_model.py
@@ -59,6 +59,7 @@ class Model:
 
     def make_log_prob_function(self):
         """Return the log probability of the model."""
+
         def log_prob(*args):
             context = contexts.InferenceContext(args, expected_vars=self._forward_context.vars)
             with context:

--- a/pymc4/_random_variables.py
+++ b/pymc4/_random_variables.py
@@ -1,4 +1,6 @@
 """
+PyMC4 random variables.
+
 Implements the RandomVariable base class (and the necessary BackendArithmetic).
 Wraps selected tfp.distributions (listed in __all__) as pm.RandomVariables.
 Implements random variables not supported by tfp as distributions.
@@ -67,9 +69,7 @@ __all__ = tfp_supported + tfp_unsupported
 
 
 class WithBackendArithmetic:
-    """
-    Helper class to implement the backend arithmetic necessary for the RandomVariable class.
-    """
+    """Helper class to implement the backend arithmetic necessary for the RandomVariable class."""
 
     def __add__(self, other):
         return self.as_tensor() + other
@@ -219,8 +219,12 @@ class DiscreteUniform(RandomVariable):
         super(DiscreteUniform, self).__init__(name, *args, **kwargs)
 
     def _base_dist(self, *args, **kwargs):
-        """A DiscreteUniform is an equiprobable Categorical over (high-low),
-        shifted up by low."""
+        """
+        Discrete uniform base distribution.
+        
+        A DiscreteUniform is an equiprobable Categorical over (high-low),
+        shifted up by low.
+        """
         low = kwargs.pop("low")
         high = kwargs.pop("high")
         probs = np.ones(high - low) / (high - low)
@@ -233,7 +237,11 @@ class DiscreteUniform(RandomVariable):
 
 class HalfStudentT(RandomVariable):
     def _base_dist(self, *args, **kwargs):
-        """A HalfStudentT is the absolute value of a StudentT."""
+        """
+        Half student-T base distribution.
+        
+        A HalfStudentT is the absolute value of a StudentT.
+        """
         return tfd.TransformedDistribution(
             distribution=tfd.StudentT(*args, **kwargs),
             bijector=tfp.bijectors.AbsoluteValue(),
@@ -243,7 +251,11 @@ class HalfStudentT(RandomVariable):
 
 class LogitNormal(RandomVariable):
     def _base_dist(self, *args, **kwargs):
-        """A LogitNormal is the standard logistic of a Normal."""
+        """
+        Logit normal base distribution.
+        
+        A LogitNormal is the standard logistic (i.e. sigmoid) of a Normal.
+        """
         return tfd.TransformedDistribution(
             distribution=tfd.Normal(*args, **kwargs),
             bijector=tfp.bijectors.Sigmoid(),
@@ -253,8 +265,12 @@ class LogitNormal(RandomVariable):
 
 class Weibull(RandomVariable):
     def _base_dist(self, *args, **kwargs):
-        """The inverse of the Weibull bijector applied to a U[0, 1] random
-        variable gives a Weibull-distributed random variable."""
+        """
+        Weibull base distribution.
+
+        The inverse of the Weibull bijector applied to a U[0, 1] random
+        variable gives a Weibull-distributed random variable.
+        """
         return tfd.TransformedDistribution(
             distribution=tfd.Uniform(low=0.0, high=1.0),
             bijector=tfp.bijectors.Invert(tfp.bijectors.Weibull(*args, **kwargs)),
@@ -269,8 +285,12 @@ class ZeroInflatedBinomial(RandomVariable):
         super(ZeroInflatedBinomial, self).__init__(name, *args, **kwargs)
 
     def _base_dist(self, *args, **kwargs):
-        """A ZeroInflatedBinomial is a mixture between a deterministic
-        distribution and a Binomial distribution."""
+        """
+        Zero-inflated binomial base distribution.
+
+        A ZeroInflatedBinomial is a mixture between a deterministic
+        distribution and a Binomial distribution.
+        """
         mix = kwargs.pop("mix")
         return tfd.Mixture(
             cat=tfd.Categorical(probs=[mix, 1.0 - mix]),
@@ -286,8 +306,12 @@ class ZeroInflatedPoisson(RandomVariable):
         super(ZeroInflatedPoisson, self).__init__(name, *args, **kwargs)
 
     def _base_dist(self, *args, **kwargs):
-        """A ZeroInflatedPoisson is a mixture between a deterministic
-        distribution and a Poisson distribution."""
+        """
+        Zero-inflated Poisson base distribution.
+
+        A ZeroInflatedPoisson is a mixture between a deterministic
+        distribution and a Poisson distribution.
+        """
         mix = kwargs.pop("mix")
         return tfd.Mixture(
             cat=tfd.Categorical(probs=[mix, 1.0 - mix]),
@@ -303,8 +327,12 @@ class ZeroInflatedNegativeBinomial(RandomVariable):
         super(ZeroInflatedNegativeBinomial, self).__init__(name, *args, **kwargs)
 
     def _base_dist(self, *args, **kwargs):
-        """A ZeroInflatedNegativeBinomial is a mixture between a deterministic
-        distribution and a NegativeBinomial distribution."""
+        """
+        Zero-inflated negative binomial base distribution.
+
+        A ZeroInflatedNegativeBinomial is a mixture between a deterministic
+        distribution and a NegativeBinomial distribution.
+        """
         mix = kwargs.pop("mix")
         return tfd.Mixture(
             cat=tfd.Categorical(probs=[mix, 1.0 - mix]),

--- a/pymc4/_template_contexts.py
+++ b/pymc4/_template_contexts.py
@@ -1,4 +1,5 @@
-"""Contexts for model template evaluation.
+"""
+Contexts for model template evaluation.
 
 When a new random variable is created, it will register
 itself with the current context on the context stack by
@@ -12,7 +13,7 @@ import threading
 
 
 class BaseContext:
-    """A context """
+    """A context."""
 
     def add_variable(self, rv):
         raise NotImplementedError("Abstract method.")

--- a/pymc4/tests/conftest.py
+++ b/pymc4/tests/conftest.py
@@ -1,6 +1,4 @@
-"""
-PyMC4 test configuration
-"""
+"""PyMC4 test configuration."""
 import pytest
 import tensorflow as tf
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+pydocstyle
 pytest
 pytest-cov
 pylint

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -4,9 +4,8 @@ set -ex # fail on first error, print commands
 
 SRC_DIR=${SRC_DIR:-`pwd`}
 
-# TODO: Add and enforce pydocstyle
-# echo "Checking documentation..."
-# python -m pydocstyle --convention=numpy ${SRC_DIR}/pymc4/
+echo "Checking documentation..."
+python -m pydocstyle --convention=numpy ${SRC_DIR}/pymc4/
 echo "Success!"
 
 echo "Checking code style with black..."

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -4,8 +4,8 @@ set -ex # fail on first error, print commands
 
 SRC_DIR=${SRC_DIR:-`pwd`}
 
-echo "Checking documentation..."
-python -m pydocstyle --convention=numpy ${SRC_DIR}/pymc4/
+echo "Checking documentation with pydocstyle..."
+python -m pydocstyle ${SRC_DIR}/pymc4/
 echo "Success!"
 
 echo "Checking code style with black..."

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[pydocstyle]
+# Ignore errors for missing docstrings
+add-ignore = D100,D101,D102,D103,D104,D105,D106,D107
+convention = numpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,6 @@
 [pydocstyle]
 # Ignore errors for missing docstrings
-add-ignore = D100,D101,D102,D103,D104,D105,D106,D107
+# Ignore D202 (no trailing) due to bug in black
+# https://github.com/ambv/black/issues/355
+add-ignore = D100,D101,D102,D103,D104,D105,D106,D107,D202
 convention = numpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [pydocstyle]
-# Ignore errors for missing docstrings
-# Ignore D202 (no trailing) due to bug in black
-# https://github.com/ambv/black/issues/355
+# Ignore errors for missing docstrings.
+# Ignore D202 (No blank lines allowed after function docstring)
+# due to bug in black: https://github.com/ambv/black/issues/355
 add-ignore = D100,D101,D102,D103,D104,D105,D106,D107,D202
 convention = numpy


### PR DESCRIPTION
Adds pydocstyle to our Travis builds, and fixes any docstrings to conform to numpy convention.

I've ignored error codes D100 through D107, which all raise errors if there are missing docstrings. In due course we will (hopefully!) get rid of those ignored errors.

Also, I made a `setup.cfg` with the configuration settings for `pydocstyle`. It seems that `black` does _not_ allow configs in a `setup.cfg` file, and instead looks for a `pyproject.toml` file. It seems unsatisfying to have so many config files littering our top-level directory.