### PR TITLE
TST: test backend arithmetic

### DIFF
--- a/pymc4/random_variables/random_variable.py
+++ b/pymc4/random_variables/random_variable.py
@@ -52,29 +52,11 @@ class WithBackendArithmetic:
     def __rmod__(self, other):
         return other % self.as_tensor()
 
-    def __divmod__(self, other):
-        return divmod(self.as_tensor(), other)
-
-    def __rdivmod__(self, other):
-        return divmod(other, self.as_tensor())
-
     def __pow__(self, other):
         return self.as_tensor() ** other
 
     def __rpow__(self, other):
         return other ** self.as_tensor()
-
-    def __lshift__(self, other):
-        return self.as_tensor() << other
-
-    def __rlshift__(self, other):
-        return other << self.as_tensor()
-
-    def __rshift__(self, other):
-        return self.as_tensor >> other
-
-    def __rrshift__(self, other):
-        return other >> self.as_tensor()
 
     def __and__(self, other):
         return self.as_tensor() & other

--- a/pymc4/tests/test_random_variables.py
+++ b/pymc4/tests/test_random_variables.py
@@ -100,13 +100,13 @@ def test_rvs_backend_arithmetic():
     x = random_variables.Normal("x", 0, 1)
     y = random_variables.Normal("y", 1, 2)
 
-    assert x + y
-    assert x - y
-    assert x * y
+    assert x + y is not None
+    assert x - y is not None
+    assert x * y is not None
     # TODO test __matmul__ once random variables support shapes.
-    # assert x @ y
-    assert x / y
-    assert x // y
-    assert x % y
-    assert x ** y
-    assert -x
+    # assert x @ y is not None
+    assert x / y is not None
+    assert x // y is not None
+    assert x % y is not None
+    assert x ** y is not None
+    assert -x is not None

--- a/pymc4/tests/test_random_variables.py
+++ b/pymc4/tests/test_random_variables.py
@@ -97,8 +97,8 @@ def test_rvs_logp_and_forward_sample(tf_session, randomvariable, kwargs):
 
 def test_rvs_backend_arithmetic():
     """Test backend arithmetic implemented by the `WithBackendArithmetic` class."""
-    x = pm.Normal("x", 0, 1)
-    y = pm.Normal("y", 1, 2)
+    x = random_variables.Normal("x", 0, 1)
+    y = random_variables.Normal("y", 1, 2)
 
     assert x + y
     assert x - y

--- a/pymc4/tests/test_random_variables.py
+++ b/pymc4/tests/test_random_variables.py
@@ -95,15 +95,16 @@ def test_rvs_logp_and_forward_sample(tf_session, randomvariable, kwargs):
             assert "NotImplementedError: sample_n is not implemented: Binomial" == str(err)
 
 
-def test_backend_arithmetic():
-    """Test that random variable backend arithmetic."""
+def test_rvs_backend_arithmetic():
+    """Test backend arithmetic implemented by the `WithBackendArithmetic` class."""
     x = pm.Normal("x", 0, 1)
     y = pm.Normal("y", 1, 2)
 
-    # TODO test __matmul__ once random variables support shapes.
     assert x + y
     assert x - y
     assert x * y
+    # TODO test __matmul__ once random variables support shapes.
+    # assert x @ y
     assert x / y
     assert x // y
     assert x % y

--- a/pymc4/tests/test_random_variables.py
+++ b/pymc4/tests/test_random_variables.py
@@ -93,3 +93,19 @@ def test_rvs_logp_and_forward_sample(tf_session, randomvariable, kwargs):
         with pytest.raises(NotImplementedError) as err:
             dist.log_prob()
             assert "NotImplementedError: sample_n is not implemented: Binomial" == str(err)
+
+
+def test_backend_arithmetic():
+    """Test that random variable backend arithmetic."""
+    x = pm.Normal("x", 0, 1)
+    y = pm.Normal("y", 1, 2)
+
+    # TODO test __matmul__ once random variables support shapes.
+    assert x + y
+    assert x - y
+    assert x * y
+    assert x / y
+    assert x // y
+    assert x % y
+    assert x ** y
+    assert -x


### PR DESCRIPTION
Adds a short test to check that the arithmetic implemented by the `WithBackendArithmetic` class do not fail.

I removed the several arithmetic operations that failed because they aren't defined on `Tensor`s. E.g., you can't compute `divmod(x, y)` when `x` and `y` are Tensors.

Similarly for `x >> 1` and `x << 1`. I'm  not even sure if it makes sense for a Bayesian modeling library to support bitshifts.