### PR TITLE
ENH: improve Makefile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,20 +75,26 @@ machine, and develop on a feature branch.
    Always create a new `feature` branch. It's best practice to never work on the
    `master` branch of any repository.
 
-4. PyMC4's dependencies are listed in `requirements.txt`, and dependencies for
-   development are listed in `requirements-dev.txt`. To get yourself set up, you
-   can (probably in a [Python virtual
-   environment](https://docs.python.org/3/library/venv.html) or [conda
-   environment](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html))
-   run:
+4. To set up a development environment for myself, you can use the `make`
+   command line utility. Depending on whether you want to develop using a
+   [Python virtual environment](https://docs.python.org/3/library/venv.html),
+   [conda
+   environment](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html)
+   or [Docker
+   image](https://docs.docker.com/develop/develop-images/image_management/), you
+   can run one of `make venv`, `make conda` or `make docker`, respectively, and
+   follow the resulting instructions (in blue) after the setup is finished.
 
-   ```bash
-   $ pip install -r requirements.txt
-   $ pip install -r requirements-dev.txt
-   ```
+5. Develop the feature on your feature branch. This is the fun part!
 
-5. Develop the feature on your feature branch. Add changed files using `git
-   add` and then `git commit`:
+6. Once you are done developing, run `make black` and `make check` from the root
+   `pymc4/` directory to blackify, lint and test the codebase. If you like, you
+   can run `make lint` and `make test` to lint and test separately. Work through
+   and fix any lint errors or failing tests. Don't hesitate to reach out to us
+   through the [GitHub issue tracker](https://github.com/pymc-devs/pymc4/issues)
+   if you run into problems!
+
+7. Add changed files using `git add` and then `git commit`:
 
    ```bash
    $ git add you_modified_file.py
@@ -103,7 +109,7 @@ machine, and develop on a feature branch.
    $ git push -u origin my-feature
    ```
 
-6. Go to the GitHub web page of your fork of the PyMC4 repo. Click the `Pull
+8. Go to the GitHub web page of your fork of the PyMC4 repo. Click the `Pull
    request` button to send your changes to the project's maintainers for review.
    This will notify the PyMC4 developers.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,10 +75,9 @@ machine, and develop on a feature branch.
    Always create a new `feature` branch. It's best practice to never work on the
    `master` branch of any repository.
 
-4. To set up a development environment for myself, you can use the `make`
-   command line utility. Depending on whether you want to develop using a
-   [Python virtual environment](https://docs.python.org/3/library/venv.html),
-   [conda
+4. To set up your development environment, you can use the `make` command line
+   utility. Depending on whether you want to develop using a [Python virtual
+   environment](https://docs.python.org/3/library/venv.html), [conda
    environment](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html)
    or [Docker
    image](https://docs.docker.com/develop/develop-images/image_management/), you

--- a/Makefile
+++ b/Makefile
@@ -12,28 +12,28 @@ help:
 
 conda:  # Set up a conda environment for development.
 	@printf "Creating conda environment...\n"
-	${CONDA} create --yes --name env python=3.6
+	${CONDA} create --yes --name pymc4-env python=3.6
 	( \
-	${CONDA} activate env; \
+	${CONDA} activate pymc4-env; \
 	${PIP} install -U pip; \
 	${PIP} install -r requirements.txt; \
 	${PIP} install -r requirements-dev.txt; \
 	${CONDA} deactivate; \
 	)
-	@printf "\n\nConda environment created! \033[1;34mRun \`conda activate env\` to activate it.\033[0m\n\n\n"
+	@printf "\n\nConda environment created! \033[1;34mRun \`conda activate pymc4-env\` to activate it.\033[0m\n\n\n"
 
 venv:  # Set up a Python virtual environment for development.
 	@printf "Creating Python virtual environment...\n"
-	rm -rf venv
-	${PYTHON} -m venv venv
+	rm -rf pymc4-venv
+	${PYTHON} -m venv pymc4-venv
 	( \
-	source venv/bin/activate; \
+	source pymc4-venv/bin/activate; \
 	${PIP} install -U pip; \
 	${PIP} install -r requirements.txt; \
 	${PIP} install -r requirements-dev.txt; \
 	deactivate; \
 	)
-	@printf "\n\nVirtual environment created! \033[1;34mRun \`source venv/bin/activate\` to activate it.\033[0m\n\n\n"
+	@printf "\n\nVirtual environment created! \033[1;34mRun \`source pymc4-venv/bin/activate\` to activate it.\033[0m\n\n\n"
 
 docker:  # Set up a Docker image for development.
 	@printf "Creating Docker image...\n"

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ venv:  # Set up a Python virtual environment for development.
 docker:  # Set up a Docker image for development.
 	@printf "Creating Docker image...\n"
 	${SHELL} ./scripts/container.sh --build
-	@printf "\n\nDocker image created! \033[1;34mRun \`source venv/bin/activate\` to activate it.\033[0m\n\n\n"
+	@printf "\n\nDocker image created! \033[1;34mRefer to pymc4/scripts/README.md for instructions on how to use it.\033[0m\n\n\n"
 
 docstyle:
 	@printf "Checking documentation with pydocstyle...\n"

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ format:
 style:
 	@printf "Checking code style with pylint...\n"
 	pylint pymc4/
-	@printf "\033[1;34mPylint passes!\033[0m\n"
+	@printf "\033[1;34mPylint passes!\033[0m\n\n"
 
 black:  # Format code in-place using black.
 	black pymc4/

--- a/Makefile
+++ b/Makefile
@@ -62,4 +62,4 @@ test:  # Test code using pytest.
 
 lint: docstyle format style  # Lint code using pydocstyle, black and pylint.
 
-check: lint test  # Lint and test code.
+check: lint test  # Both lint and test code. Runs `make lint` followed by `make test`.

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,43 @@
+.PHONY: help venv conda docker docstyle format style black test lint check
+.DEFAULT_GOAL = help
+
+PYTHON = python3
+PIP = pip3
+CONDA = conda
+SHELL = bash
+
+help:
+	@printf "Usage:\n\n"
+	@grep -E '^[a-zA-Z_-]+:.*?# .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?# "}; {printf "\033[1;34mmake %-10s\033[0m %s\n", $$1, $$2}'
+
+conda:  # Set up a conda environment for development.
+	@printf "Creating conda environment...\n"
+	${CONDA} create --name env
+	( \
+	source env/bin/activate; \
+	${CONDA} install -r requirements.txt; \
+	${CONDA} install -r requirements-dev.txt; \
+	deactivate; \
+	)
+	@printf "\n\nConda environment created! \033[1;34mRun \`source env/bin/activate\` to activate it.\033[0m\n\n\n"
+
+venv:  # Set up a Python virtual environment for development.
+	@printf "Creating Python virtual environment...\n"
+	${PYTHON} -m venv venv
+	( \
+	source venv/bin/activate; \
+	${PIP} install -U pip; \
+	${PIP} install -r requirements.txt; \
+	${PIP} install -r requirements-dev.txt; \
+	deactivate; \
+	)
+	@printf "\n\nVirtual environment created! \033[1;34mRun \`source venv/bin/activate\` to activate it.\033[0m\n\n\n"
+
+docker:  # Set up a Docker image for development.
+	@printf "Creating Docker image...\n"
+	${SHELL} ./scripts/container.sh --build
+	@printf "\n\nDocker image created! \033[1;34mRun \`source venv/bin/activate\` to activate it.\033[0m\n\n\n"
+
 docstyle:
 	@echo "Checking documentation with pydocstyle..."
 	pydocstyle pymc4/

--- a/Makefile
+++ b/Makefile
@@ -12,14 +12,14 @@ help:
 
 conda:  # Set up a conda environment for development.
 	@printf "Creating conda environment...\n"
-	${CONDA} create --name env
+	${CONDA} create --yes --name env
 	( \
-	source env/bin/activate; \
-	${CONDA} install -r requirements.txt; \
-	${CONDA} install -r requirements-dev.txt; \
-	deactivate; \
+	source activate env; \
+	${CONDA} install --yes --file requirements.txt; \
+	${CONDA} install --yes --file requirements-dev.txt; \
+	conda deactivate; \
 	)
-	@printf "\n\nConda environment created! \033[1;34mRun \`source env/bin/activate\` to activate it.\033[0m\n\n\n"
+	@printf "\n\nConda environment created! \033[1;34mRun \`source activate env\` to activate it.\033[0m\n\n\n"
 
 venv:  # Set up a Python virtual environment for development.
 	@printf "Creating Python virtual environment...\n"

--- a/Makefile
+++ b/Makefile
@@ -41,17 +41,17 @@ docker:  # Set up a Docker image for development.
 docstyle:
 	@printf "Checking documentation with pydocstyle...\n"
 	pydocstyle pymc4/
-	@printf "Pydocstyle passes!\n\n"
+	@printf "\033[1;34mPydocstyle passes!\033[0m\n\n"
 
 format:
 	@printf "Checking code style with black...\n"
 	black --check pymc4/
-	@printf "Black passes!\n\n"
+	@printf "\033[1;34mBlack passes!\033[0m\n\n"
 
 style:
 	@printf "Checking code style with pylint...\n"
 	pylint pymc4/
-	@printf "Pylint passes!\n\n"
+	@printf "\033[1;34mPylint passes!\033[0m\n"
 
 black:  # Format code in-place using black.
 	black pymc4/

--- a/Makefile
+++ b/Makefile
@@ -39,20 +39,19 @@ docker:  # Set up a Docker image for development.
 	@printf "\n\nDocker image created! \033[1;34mRun \`source venv/bin/activate\` to activate it.\033[0m\n\n\n"
 
 docstyle:
-	@echo "Checking documentation with pydocstyle..."
+	@printf "Checking documentation with pydocstyle...\n"
 	pydocstyle pymc4/
-	@echo "Pydocstyle passes!\n"
-
+	@printf "Pydocstyle passes!\n\n"
 
 format:
-	@echo "Checking code style with black..."
+	@printf "Checking code style with black...\n"
 	black --check pymc4/
-	@echo "Black passes!\n"
+	@printf "Black passes!\n\n"
 
 style:
-	@echo "Checking code style with pylint..."
+	@printf "Checking code style with pylint...\n"
 	pylint pymc4/
-	@echo "Pylint passes!\n"
+	@printf "Pylint passes!\n\n"
 
 black:
 	black pymc4/

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ conda:  # Set up a conda environment for development.
 
 venv:  # Set up a Python virtual environment for development.
 	@printf "Creating Python virtual environment...\n"
+	rm -rf venv
 	${PYTHON} -m venv venv
 	( \
 	source venv/bin/activate; \

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY: help venv conda docker docstyle format style black test lint check
 .DEFAULT_GOAL = help
 
-PYTHON = python3
-PIP = pip3
+PYTHON = python
+PIP = pip
 CONDA = conda
 SHELL = bash
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY: help venv conda docker docstyle format style black test lint check
 .DEFAULT_GOAL = help
 
-PYTHON = python
-PIP = pip
+PYTHON = python3
+PIP = pip3
 CONDA = conda
 SHELL = bash
 

--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,13 @@ conda:  # Set up a conda environment for development.
 	@printf "Creating conda environment...\n"
 	${CONDA} create --yes --name env python=3.6
 	( \
-	source activate env; \
+	${CONDA} activate env; \
 	${PIP} install -U pip; \
 	${PIP} install -r requirements.txt; \
 	${PIP} install -r requirements-dev.txt; \
-	conda deactivate; \
+	${CONDA} deactivate; \
 	)
-	@printf "\n\nConda environment created! \033[1;34mRun \`source activate env\` to activate it.\033[0m\n\n\n"
+	@printf "\n\nConda environment created! \033[1;34mRun \`conda activate env\` to activate it.\033[0m\n\n\n"
 
 venv:  # Set up a Python virtual environment for development.
 	@printf "Creating Python virtual environment...\n"

--- a/Makefile
+++ b/Makefile
@@ -53,13 +53,12 @@ style:
 	pylint pymc4/
 	@printf "Pylint passes!\n\n"
 
-black:
+black:  # Format code in-place using black.
 	black pymc4/
 
-test:
+test:  # Test code using pytest.
 	pytest -v pymc4/tests/ --cov=pymc4/ --html=testing-report.html --self-contained-html
 
+lint: docstyle format style  # Lint code using pydocstyle, black and pylint.
 
-lint: docstyle format style
-
-check: lint black test
+check: lint test  # Lint and test code.

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,12 @@ help:
 
 conda:  # Set up a conda environment for development.
 	@printf "Creating conda environment...\n"
-	${CONDA} create --yes --name env
+	${CONDA} create --yes --name env python=3.6
 	( \
 	source activate env; \
-	${CONDA} install --yes --file requirements.txt; \
-	${CONDA} install --yes --file requirements-dev.txt; \
+	${PIP} install -U pip; \
+	${PIP} install -r requirements.txt; \
+	${PIP} install -r requirements-dev.txt; \
 	conda deactivate; \
 	)
 	@printf "\n\nConda environment created! \033[1;34mRun \`source activate env\` to activate it.\033[0m\n\n\n"

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ CONDA = conda
 SHELL = bash
 
 help:
-	@printf "Usage:\n\n"
-	@grep -E '^[a-zA-Z_-]+:.*?# .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?# "}; {printf "\033[1;34mmake %-10s\033[0m %s\n", $$1, $$2}'
+	@printf "Usage:\n"
+	@grep -E '^[a-zA-Z_-]+:.*?# .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?# "}; {printf "\033[1;34mmake %-10s\033[0m%s\n", $$1, $$2}'
 
 conda:  # Set up a conda environment for development.
 	@printf "Creating conda environment...\n"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,12 +1,12 @@
 # Docker FAQ
 
-* Image can be built locally using command
+* Image can be built locally using the command `make docker` or the command
  `./scripts/container.sh --build` from the root `pymc4` directory
  
 * After image is built an interactive bash session can be run 
 `docker run -it pymc4 bash`
 
-* Command can be issused to the container such as linting and testing
+* Command can be issued to the container such as linting and testing
  without interactive session
   * `docker run pymc4 bash -c "pytest pymc4/tests"`
   * `docker run pymc4 bash -c "./scripts/lint.sh"`


### PR DESCRIPTION
A few improvements:

1. Added a help command. Running `make` now gives you:

```
Usage:

make conda      Set up a conda environment for development.
make venv       Set up a Python virtual environment for development.
make docker     Set up a Docker image for development.
make black      Format code in-place using black.
make test       Test code using pytest.
make lint       Lint code using pydocstyle, black and pylint.
make check      Both lint and test code. Runs `make lint` followed by `make test`.
```

2. Added rules to set up development environments: `make conda`, `make venv` and `make docker`.
3. Changed from `echo` to `printf`. [According to this SO post](https://stackoverflow.com/a/14121245), `make` is a bit treacherous with `echo`, and _may_ print newlines as `\n` depending on your shell or OS. Changing them all to `printf` is the simplest solution.
4. Removed `black` from the recipe for `make check`: `make check` should only check your code, not modify it!