### PR TITLE
Auto name RVs by parsing AST

### DIFF
--- a/pymc4/_model.py
+++ b/pymc4/_model.py
@@ -94,7 +94,7 @@ class Model:
     def forward_sample(self, *args, **kwargs):
         """Simulate data from the model via forward sampling."""
         with self._forward_context as context:
-            samples = {var.name: var.as_tensor() for var in context.vars}
+            samples = {var.name: var.sample() for var in context.vars}
         return samples
 
     def observe(self, **kwargs):

--- a/pymc4/_model.py
+++ b/pymc4/_model.py
@@ -10,7 +10,7 @@ import tensorflow as tf
 __all__ = ["model"]
 
 
-def model(auto_name=False):
+def model(_func=None, *, auto_name=False):
     """
     Decorate a model-specification function as a PyMC4 model.
 
@@ -23,6 +23,7 @@ def model(auto_name=False):
     -------
     The function wrapped in a ModelTemplate object.
     """
+
     def wrap(func):
         if auto_name:
             # uncompile function
@@ -39,7 +40,10 @@ def model(auto_name=False):
 
         return ModelTemplate(func)
 
-    return wrap
+    if _func is None:
+        return wrap
+    else:
+        return wrap(_func)
 
 
 class ModelTemplate:

--- a/pymc4/ast_compiler.py
+++ b/pymc4/ast_compiler.py
@@ -80,20 +80,20 @@ def recompile(source, filename, mode, flags=0, firstlineno=1, privateprefix=None
             return tuple(privateprefix + name if isprivate(name) else name for name in names)
 
         c = code(
-            c.co_argcount, # pylint: disable=undefined-loop-variable
-            c.co_nlocals, # pylint: disable=undefined-loop-variable
-            c.co_stacksize, # pylint: disable=undefined-loop-variable
-            c.co_flags, # pylint: disable=undefined-loop-variable
-            c.co_code, # pylint: disable=undefined-loop-variable
-            c.co_consts, # pylint: disable=undefined-loop-variable
-            fixnames(c.co_names), # pylint: disable=undefined-loop-variable
-            fixnames(c.co_varnames), # pylint: disable=undefined-loop-variable
-            c.co_filename, # pylint: disable=undefined-loop-variable
-            c.co_name, # pylint: disable=undefined-loop-variable
-            c.co_firstlineno, # pylint: disable=undefined-loop-variable
-            c.co_lnotab, # pylint: disable=undefined-loop-variable
-            c.co_freevars, # pylint: disable=undefined-loop-variable
-            c.co_cellvars, # pylint: disable=undefined-loop-variable
+            c.co_argcount,  # pylint: disable=undefined-loop-variable
+            c.co_nlocals,  # pylint: disable=undefined-loop-variable
+            c.co_stacksize,  # pylint: disable=undefined-loop-variable
+            c.co_flags,  # pylint: disable=undefined-loop-variable
+            c.co_code,  # pylint: disable=undefined-loop-variable
+            c.co_consts,  # pylint: disable=undefined-loop-variable
+            fixnames(c.co_names),  # pylint: disable=undefined-loop-variable
+            fixnames(c.co_varnames),  # pylint: disable=undefined-loop-variable
+            c.co_filename,  # pylint: disable=undefined-loop-variable
+            c.co_name,  # pylint: disable=undefined-loop-variable
+            c.co_firstlineno,  # pylint: disable=undefined-loop-variable
+            c.co_lnotab,  # pylint: disable=undefined-loop-variable
+            c.co_freevars,  # pylint: disable=undefined-loop-variable
+            c.co_cellvars,  # pylint: disable=undefined-loop-variable
         )
     return c
 

--- a/pymc4/ast_compiler.py
+++ b/pymc4/ast_compiler.py
@@ -1,7 +1,7 @@
 # Taken from http://code.activestate.com/recipes/578353-code-to-source-and-back/
 
 import ast, inspect, re
-from types import CodeType as code, FunctionType as function
+from types import CodeType as code
 
 import __future__
 
@@ -80,20 +80,20 @@ def recompile(source, filename, mode, flags=0, firstlineno=1, privateprefix=None
             return tuple(privateprefix + name if isprivate(name) else name for name in names)
 
         c = code(
-            c.co_argcount,
-            c.co_nlocals,
-            c.co_stacksize,
-            c.co_flags,
-            c.co_code,
-            c.co_consts,
-            fixnames(c.co_names),
-            fixnames(c.co_varnames),
-            c.co_filename,
-            c.co_name,
-            c.co_firstlineno,
-            c.co_lnotab,
-            c.co_freevars,
-            c.co_cellvars,
+            c.co_argcount, # pylint: disable=undefined-loop-variable
+            c.co_nlocals, # pylint: disable=undefined-loop-variable
+            c.co_stacksize, # pylint: disable=undefined-loop-variable
+            c.co_flags, # pylint: disable=undefined-loop-variable
+            c.co_code, # pylint: disable=undefined-loop-variable
+            c.co_consts, # pylint: disable=undefined-loop-variable
+            fixnames(c.co_names), # pylint: disable=undefined-loop-variable
+            fixnames(c.co_varnames), # pylint: disable=undefined-loop-variable
+            c.co_filename, # pylint: disable=undefined-loop-variable
+            c.co_name, # pylint: disable=undefined-loop-variable
+            c.co_firstlineno, # pylint: disable=undefined-loop-variable
+            c.co_lnotab, # pylint: disable=undefined-loop-variable
+            c.co_freevars, # pylint: disable=undefined-loop-variable
+            c.co_cellvars, # pylint: disable=undefined-loop-variable
         )
     return c
 

--- a/pymc4/ast_compiler.py
+++ b/pymc4/ast_compiler.py
@@ -25,7 +25,7 @@ class NoSource(Error):
 
 
 def uncompile(c):
-    """ uncompile(codeobj) -> [source, filename, mode, flags, firstlineno, privateprefix] """
+    """uncompile(codeobj) -> [source, filename, mode, flags, firstlineno, privateprefix]."""
     if c.co_flags & inspect.CO_NESTED or c.co_freevars:
         raise Unsupported("nested functions not supported")
     if c.co_name == "<lambda>":
@@ -52,7 +52,7 @@ def uncompile(c):
 
 
 def recompile(source, filename, mode, flags=0, firstlineno=1, privateprefix=None):
-    """ recompile output of uncompile back to a code object. source may also be preparsed AST """
+    """Recompile output of uncompile back to a code object. source may also be preparsed AST."""
     if isinstance(source, ast.AST):
         a = source
     else:
@@ -99,7 +99,7 @@ def recompile(source, filename, mode, flags=0, firstlineno=1, privateprefix=None
 
 
 def parse_snippet(source, filename, mode, flags, firstlineno, privateprefix_ignored=None):
-    """ Like ast.parse, but accepts indented code snippet with a line number offset. """
+    """Like ast.parse, but accepts indented code snippet with a line number offset."""
     args = filename, mode, flags | ast.PyCF_ONLY_AST, True
     prefix = "\n"
     try:

--- a/pymc4/ast_compiler.py
+++ b/pymc4/ast_compiler.py
@@ -1,0 +1,101 @@
+# Taken from http://code.activestate.com/recipes/578353-code-to-source-and-back/
+
+import ast, inspect, re
+from types import CodeType as code, FunctionType as function
+
+import __future__
+PyCF_MASK = sum(v for k, v in vars(__future__).items() if k.startswith('CO_FUTURE'))
+
+class Error(Exception):
+    pass
+
+class Unsupported(Error):
+    pass
+
+class NoSource(Error):
+    pass
+
+def uncompile(c):
+    """ uncompile(codeobj) -> [source, filename, mode, flags, firstlineno, privateprefix] """
+    if c.co_flags & inspect.CO_NESTED or c.co_freevars:
+        raise Unsupported('nested functions not supported')
+    if c.co_name == '<lambda>':
+        raise Unsupported('lambda functions not supported')
+    if c.co_filename == '<string>':
+        raise Unsupported('code without source file not supported')
+
+    filename = inspect.getfile(c)
+    try:
+        lines, firstlineno = inspect.getsourcelines(c)
+    except IOError:
+        raise NoSource('source code not available')
+    source = ''.join(lines)
+
+    # __X is mangled to _ClassName__X in methods. Find this prefix:
+    privateprefix = None
+    for name in c.co_names:
+        m = re.match('^(_[A-Za-z][A-Za-z0-9_]*)__.*$', name)
+        if m:
+            privateprefix = m.group(1)
+            break
+
+    return [source, filename, 'exec', c.co_flags & PyCF_MASK, firstlineno, privateprefix]
+
+def recompile(source, filename, mode, flags=0, firstlineno=1, privateprefix=None):
+    """ recompile output of uncompile back to a code object. source may also be preparsed AST """
+    if isinstance(source, ast.AST):
+        a = source
+    else:
+        a = parse_snippet(source, filename, mode, flags, firstlineno)
+    node = a.body[0]
+    if not isinstance(node, ast.FunctionDef):
+        raise Error('Expecting function AST node')
+
+    c0 = compile(a, filename, mode, flags, True)
+
+    # This code object defines the function. Find the function's actual body code:
+    for c in c0.co_consts:
+        if not isinstance(c, code):
+            continue
+        if c.co_name == node.name and c.co_firstlineno == node.lineno:
+            break
+    else:
+        raise Error('Function body code not found')
+
+    # Re-mangle private names:
+    if privateprefix is not None:
+
+        def fixnames(names):
+            isprivate = re.compile('^__.*(?<!__)$').match
+            return tuple(privateprefix + name if isprivate(name) else name for name in names)
+
+        c = code(c.co_argcount, c.co_nlocals, c.co_stacksize, c.co_flags, c.co_code, c.co_consts,
+                fixnames(c.co_names), fixnames(c.co_varnames), c.co_filename, c.co_name,
+                c.co_firstlineno, c.co_lnotab, c.co_freevars, c.co_cellvars)
+    return c
+
+def parse_snippet(source, filename, mode, flags, firstlineno, privateprefix_ignored=None):
+    """ Like ast.parse, but accepts indented code snippet with a line number offset. """
+    args = filename, mode, flags | ast.PyCF_ONLY_AST, True
+    prefix = '\n'
+    try:
+        a = compile(prefix + source, *args)
+    except IndentationError:
+        # Already indented? Wrap with dummy compound statement
+        prefix = 'with 0:\n'
+        a = compile(prefix + source, *args)
+        # peel wrapper
+        a.body = a.body[0].body
+    ast.increment_lineno(a, firstlineno - 2)
+    return a
+
+class AutoNameTransformer(ast.NodeTransformer):
+    def visit_Assign(self, tree_node):
+        rv_name = tree_node.targets[0].id
+        # Test if name keyword is already set
+        if any(kwarg.arg == 'name' for kwarg in tree_node.value.keywords):
+            return tree_node
+        else:
+            tree_node.value.keywords.append(ast.keyword('name', ast.Str(rv_name)))
+
+        return tree_node

--- a/pymc4/random_variables/discrete.py
+++ b/pymc4/random_variables/discrete.py
@@ -527,10 +527,7 @@ class ZeroInflatedNegativeBinomial(DiscreteRV):
     def _base_dist(self, psi: TensorLike, mu: TensorLike, alpha: TensorLike, *args, **kwargs):
         return pm.Mixture(
             p=[psi, 1.0 - psi],
-            distributions=[
-                pm.Constant(value=0),
-                pm.NegativeBinomial(mu=mu, alpha=alpha),
-            ],
+            distributions=[pm.Constant(value=0), pm.NegativeBinomial(mu=mu, alpha=alpha)],
             name="ZeroInflatedNegativeBinomial",
         )._distribution
 

--- a/pymc4/random_variables/discrete.py
+++ b/pymc4/random_variables/discrete.py
@@ -452,7 +452,7 @@ class ZeroInflatedBinomial(DiscreteRV):
         """
         return pm.Mixture(
             p=[psi, 1.0 - psi],
-            distributions=[pm.Constant("Zero", 0), pm.Binomial("Binomial", n, p)],
+            distributions=[pm.Constant(0), pm.Binomial(n, p)],
             name="ZeroInflatedBinomial",
         )._distribution
 
@@ -528,8 +528,8 @@ class ZeroInflatedNegativeBinomial(DiscreteRV):
         return pm.Mixture(
             p=[psi, 1.0 - psi],
             distributions=[
-                pm.Constant(name="Zero", value=0),
-                pm.NegativeBinomial(name="NegativeBinomial", mu=mu, alpha=alpha),
+                pm.Constant(value=0),
+                pm.NegativeBinomial(mu=mu, alpha=alpha),
             ],
             name="ZeroInflatedNegativeBinomial",
         )._distribution
@@ -589,6 +589,6 @@ class ZeroInflatedPoisson(DiscreteRV):
     def _base_dist(self, psi: TensorLike, theta: TensorLike, *args, **kwargs):
         return pm.Mixture(
             p=[psi, 1.0 - psi],
-            distributions=[pm.Constant(name="Zero", value=0), pm.Poisson(name="Poisson", mu=theta)],
+            distributions=[pm.Constant(value=0), pm.Poisson(mu=theta)],
             name="ZeroInflatedPoisson",
         )._distribution

--- a/pymc4/random_variables/discrete.py
+++ b/pymc4/random_variables/discrete.py
@@ -452,7 +452,7 @@ class ZeroInflatedBinomial(DiscreteRV):
         """
         return pm.Mixture(
             p=[psi, 1.0 - psi],
-            distributions=[pm.Constant(0), pm.Binomial(n, p)],
+            distributions=[pm.Constant(0, name="Zero"), pm.Binomial(n, p, name="Bin")],
             name="ZeroInflatedBinomial",
         )._distribution
 
@@ -527,7 +527,10 @@ class ZeroInflatedNegativeBinomial(DiscreteRV):
     def _base_dist(self, psi: TensorLike, mu: TensorLike, alpha: TensorLike, *args, **kwargs):
         return pm.Mixture(
             p=[psi, 1.0 - psi],
-            distributions=[pm.Constant(value=0), pm.NegativeBinomial(mu=mu, alpha=alpha)],
+            distributions=[
+                pm.Constant(value=0, name="Zero"),
+                pm.NegativeBinomial(mu=mu, alpha=alpha, name="NegBin"),
+            ],
             name="ZeroInflatedNegativeBinomial",
         )._distribution
 
@@ -586,6 +589,6 @@ class ZeroInflatedPoisson(DiscreteRV):
     def _base_dist(self, psi: TensorLike, theta: TensorLike, *args, **kwargs):
         return pm.Mixture(
             p=[psi, 1.0 - psi],
-            distributions=[pm.Constant(value=0), pm.Poisson(mu=theta)],
+            distributions=[pm.Constant(value=0, name="Zero"), pm.Poisson(mu=theta, name="Poisson")],
             name="ZeroInflatedPoisson",
         )._distribution

--- a/pymc4/random_variables/random_variable.py
+++ b/pymc4/random_variables/random_variable.py
@@ -118,7 +118,7 @@ class RandomVariable(WithBackendArithmetic):
         self._dim_names = ()
         ctx = contexts.get_context()
         self.name = kwargs.get("name", None)
-        if isinstance(ctx, contexts.InferenceContext) and self.name is None:
+        if not isinstance(ctx, contexts.FreeForwardContext) and self.name is None:
             # We only require names for book keeping during inference
             raise ValueError("No name was set in InferenceContext. Supply one via the name kwarg.")
 

--- a/pymc4/random_variables/random_variable.py
+++ b/pymc4/random_variables/random_variable.py
@@ -116,10 +116,12 @@ class RandomVariable(WithBackendArithmetic):
         self._distribution = self._base_dist(*args, **kwargs)
         self._sample_shape = ()
         self._dim_names = ()
-        self.name = kwargs.get('name', None)
-        if self.name is None:
-            raise ValueError('No name was set. Supply one via the name kwarg.')
         ctx = contexts.get_context()
+        self.name = kwargs.get('name', None)
+        if isinstance(ctx, contexts.InferenceContext) and self.name is None:
+            # We only require names for book keeping during inference
+            raise ValueError('No name was set in InferenceContext. Supply one via the name kwarg.')
+
         self._creation_context_id = id(ctx)
         self._backend_tensor = None
         ctx.add_variable(self)

--- a/pymc4/random_variables/random_variable.py
+++ b/pymc4/random_variables/random_variable.py
@@ -111,12 +111,14 @@ class RandomVariable(WithBackendArithmetic):
 
     _base_dist = None
 
-    def __init__(self, name: str, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         self._parents = []
-        self._distribution = self._base_dist(name=name, *args, **kwargs)
+        self._distribution = self._base_dist(*args, **kwargs)
         self._sample_shape = ()
         self._dim_names = ()
-        self.name = name
+        self.name = kwargs.get('name', None)
+        if self.name is None:
+            raise ValueError('No name was set. Supply one via the name kwarg.')
         ctx = contexts.get_context()
         self._creation_context_id = id(ctx)
         self._backend_tensor = None

--- a/pymc4/random_variables/random_variable.py
+++ b/pymc4/random_variables/random_variable.py
@@ -117,10 +117,10 @@ class RandomVariable(WithBackendArithmetic):
         self._sample_shape = ()
         self._dim_names = ()
         ctx = contexts.get_context()
-        self.name = kwargs.get('name', None)
+        self.name = kwargs.get("name", None)
         if isinstance(ctx, contexts.InferenceContext) and self.name is None:
             # We only require names for book keeping during inference
-            raise ValueError('No name was set in InferenceContext. Supply one via the name kwarg.')
+            raise ValueError("No name was set in InferenceContext. Supply one via the name kwarg.")
 
         self._creation_context_id = id(ctx)
         self._backend_tensor = None

--- a/pymc4/tests/test_autoname.py
+++ b/pymc4/tests/test_autoname.py
@@ -2,21 +2,26 @@
 Tests for PyMC4 auto naming.
 """
 
+# AST parsing only works in non-nested functions, thus place things into module namespace
 import pymc4 as pm
+
+# AST looks different if we use pm.Normal or just Normal
 from pymc4 import Normal
 
 
 def create_rvs(**kwargs):
-    return pm.Normal(0, 1, name="test")
+    # AST parsers should just add name kwargs to pymc4 RVs
+    assert "name" not in kwargs.keys()
+    return pm.Normal(0, 1, name="inside_function")
 
 
 @pm.model(auto_name=True)
 def autoname_test():
-    mu = pm.Normal(0, 1)
-    mu2 = Normal(0, 1)
-    mu3 = pm.random_variables.Normal(0, 1)
-    pm.Normal(0, 1, name="custom")
-    dummy = pm.Normal(0, 1, name="custom2")
+    inferred_w_module = pm.Normal(0, 1)
+    inferred_wo_module = Normal(0, 1)
+    inferred_full_path = pm.random_variables.Normal(0, 1)
+    pm.Normal(0, 1, name="supplied_name")
+    dummy = pm.Normal(0, 1, name="overwrite_name")
     x = create_rvs()
 
 
@@ -24,6 +29,13 @@ def test_auto_name():
     model = autoname_test.configure()
 
     rv_names = [rv.name for rv in model._forward_context.vars]
-    expected_rv_names = ["mu", "mu2", "mu3", "custom", "custom2", "test"]
+    expected_rv_names = [
+        "inferred_w_module",
+        "inferred_wo_module",
+        "inferred_full_path",
+        "supplied_name",
+        "overwrite_name",
+        "inside_function",
+    ]
 
     assert rv_names == expected_rv_names

--- a/pymc4/tests/test_autoname.py
+++ b/pymc4/tests/test_autoname.py
@@ -2,8 +2,6 @@
 Tests for PyMC4 auto naming.
 """
 
-from .. import model
-
 import pymc4 as pm
 from pymc4 import Normal
 

--- a/pymc4/tests/test_autoname.py
+++ b/pymc4/tests/test_autoname.py
@@ -2,12 +2,10 @@
 Tests for PyMC4 auto naming.
 """
 
-import pytest
-from .. import random_variables, _template_contexts, model
+from .. import model
 
 import pymc4 as pm
 from pymc4 import Normal
-
 
 def create_rvs(**kwargs):
     return pm.Normal(0, 1, name="test")

--- a/pymc4/tests/test_autoname.py
+++ b/pymc4/tests/test_autoname.py
@@ -1,0 +1,29 @@
+"""
+Tests for PyMC4 auto naming.
+"""
+
+import pytest
+from .. import random_variables, _template_contexts, model
+
+import pymc4 as pm
+from pymc4 import Normal
+
+def create_rvs(**kwargs):
+    return pm.Normal(0, 1, name='test')
+
+@pm.model(auto_name=True)
+def autoname_test():
+    mu = pm.Normal(0, 1)
+    mu2 = Normal(0, 1)
+    mu3 = pm.random_variables.Normal(0, 1)
+    pm.Normal(0, 1, name='custom')
+    dummy = pm.Normal(0, 1, name='custom2')
+    x = create_rvs()
+
+def test_auto_name():
+    model = autoname_test.configure()
+
+    rv_names = [rv.name for rv in model._forward_context.vars]
+    expected_rv_names = ['mu', 'mu2', 'mu3', 'custom', 'custom2', 'test']
+
+    assert rv_names == expected_rv_names

--- a/pymc4/tests/test_autoname.py
+++ b/pymc4/tests/test_autoname.py
@@ -8,22 +8,25 @@ from .. import random_variables, _template_contexts, model
 import pymc4 as pm
 from pymc4 import Normal
 
+
 def create_rvs(**kwargs):
-    return pm.Normal(0, 1, name='test')
+    return pm.Normal(0, 1, name="test")
+
 
 @pm.model(auto_name=True)
 def autoname_test():
     mu = pm.Normal(0, 1)
     mu2 = Normal(0, 1)
     mu3 = pm.random_variables.Normal(0, 1)
-    pm.Normal(0, 1, name='custom')
-    dummy = pm.Normal(0, 1, name='custom2')
+    pm.Normal(0, 1, name="custom")
+    dummy = pm.Normal(0, 1, name="custom2")
     x = create_rvs()
+
 
 def test_auto_name():
     model = autoname_test.configure()
 
     rv_names = [rv.name for rv in model._forward_context.vars]
-    expected_rv_names = ['mu', 'mu2', 'mu3', 'custom', 'custom2', 'test']
+    expected_rv_names = ["mu", "mu2", "mu3", "custom", "custom2", "test"]
 
     assert rv_names == expected_rv_names

--- a/pymc4/tests/test_autoname.py
+++ b/pymc4/tests/test_autoname.py
@@ -7,6 +7,7 @@ from .. import model
 import pymc4 as pm
 from pymc4 import Normal
 
+
 def create_rvs(**kwargs):
     return pm.Normal(0, 1, name="test")
 

--- a/pymc4/tests/test_random_variables.py
+++ b/pymc4/tests/test_random_variables.py
@@ -108,8 +108,8 @@ def test_rvs_logp_and_forward_sample(tf_session, randomvariable, kwargs):
 
 def test_rvs_backend_arithmetic(tf_session):
     """Test backend arithmetic implemented by the `WithBackendArithmetic` class."""
-    x = random_variables.Normal("x", mu=0, sigma=1)
-    y = random_variables.Normal("y", mu=1, sigma=2)
+    x = random_variables.Normal(mu=0, sigma=1)
+    y = random_variables.Normal(mu=1, sigma=2)
 
     assert x + y is not None
     assert x - y is not None

--- a/pymc4/tests/test_template_context.py
+++ b/pymc4/tests/test_template_context.py
@@ -54,7 +54,7 @@ def test_forward_context_add_variable(monkeypatch, tf_session):
 
     @model
     def test_model():
-        random_variables.Normal(mu=0, sigma=1)
+        random_variables.Normal(mu=0, sigma=1, name="test")
 
     # Check that correct context is utilized
     monkeypatch.setattr(
@@ -73,7 +73,7 @@ def test_forward_context_var_as_backend_tensor(monkeypatch, tf_session):
 
     @model
     def test_model():
-        random_variables.Normal(mu=0, sigma=1)
+        random_variables.Normal(mu=0, sigma=1, name="test")
 
     _model = test_model.configure()
 

--- a/pymc4/tests/test_template_context.py
+++ b/pymc4/tests/test_template_context.py
@@ -28,7 +28,7 @@ def test_free_forward_context_add_variable(monkeypatch):
     )
 
     with pytest.raises(Exception) as err:
-        random_variables.Normal("test_normal", mu=0, sigma=1)
+        random_variables.Normal(mu=0, sigma=1)
         assert err_string in str(err)
 
 
@@ -41,7 +41,7 @@ def test_free_forward_context_var_as_backend_tensor(monkeypatch):
         _template_contexts.FreeForwardContext, "var_as_backend_tensor", raise_exception(err_string)
     )
 
-    var = random_variables.Normal("test_normal", mu=0, sigma=1)
+    var = random_variables.Normal(mu=0, sigma=1)
     with pytest.raises(Exception) as err:
         var.as_tensor()
         assert err_string in str(err)
@@ -54,7 +54,7 @@ def test_forward_context_add_variable(monkeypatch, tf_session):
 
     @model
     def test_model():
-        random_variables.Normal("test_normal", mu=0, sigma=1)
+        random_variables.Normal(mu=0, sigma=1)
 
     # Check that correct context is utilized
     monkeypatch.setattr(
@@ -73,7 +73,7 @@ def test_forward_context_var_as_backend_tensor(monkeypatch, tf_session):
 
     @model
     def test_model():
-        random_variables.Normal("test_normal", mu=0, sigma=1)
+        random_variables.Normal(mu=0, sigma=1)
 
     _model = test_model.configure()
 


### PR DESCRIPTION
Based on #83. See #79 for more discussion.

![image](https://user-images.githubusercontent.com/674200/53683552-5d890300-3d02-11e9-99ca-6ffaf5b4c0f4.png)

This code directly rewrite the bytecode of the function which is quite elegant because it all looks and runs the same. For example, debugging still works:
![image](https://user-images.githubusercontent.com/674200/53683928-397bf080-3d07-11e9-8851-0be513ced270.png)

We can also easily detect cases where we can't infer the name and raise an exception that no name was provided.
