### PR TITLE
Fix black settings in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
 line-length = 100
-py36 = true
+target-version = ['py36', 'py37']


### PR DESCRIPTION
As was done in #99; this fixes a known error/warning when linter is run.  