### PR TITLE
[WIP] Add TF2 fix to notebook

### DIFF
--- a/notebooks/example_models.ipynb
+++ b/notebooks/example_models.ipynb
@@ -9,7 +9,8 @@
     "import pymc4 as pm\n",
     "import tensorflow as tf\n",
     "import numpy as np\n",
-    "import matplotlib.pyplot as plt"
+    "import matplotlib.pyplot as plt\n",
+    "from tensorflow.compat.v1 import ConfigProto, InteractiveSession, OptimizerOptions"
    ]
   },
   {
@@ -18,12 +19,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "config = tf.ConfigProto()\n",
+    "config = ConfigProto()\n",
     "config.graph_options.optimizer_options.global_jit_level = (\n",
-    "    tf.OptimizerOptions.ON_1)\n",
+    "    OptimizerOptions.ON_1)\n",
     "config.intra_op_parallelism_threads = 1\n",
     "config.inter_op_parallelism_threads = 1\n",
-    "sess = tf.InteractiveSession(config=config)"
+    "sess = InteractiveSession(config=config)"
    ]
   },
   {
@@ -472,9 +473,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "GSoC",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "gsoc"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -486,7 +487,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
`example_models.ipynb` was calling some tf1 functions, which I've re-directed towards the TF1/2 compat. layer.  This change fixes the imports, but there's still something in cell 3 that leads to `TypeError: _DistributionMeta object got multiple values for keyword argument 'scale'`