### PR TITLE
Tensorflow backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,9 @@ venv.bak/
 .idea
 *.iml
 
+# Vim
+*.swp
+
 # OS generated files
 .DS_Store
 .DS_Store?

--- a/pymc4/distributions/__init__.py
+++ b/pymc4/distributions/__init__.py
@@ -1,1 +1,8 @@
-from . import base
+__backend = 'tensorflow'
+
+if __backend == 'base':
+    from .base import *
+elif __backend == 'tensorflow':
+    from .tensorflow import *
+else:
+    raise Exception('Backend %s not supported' % __backend)

--- a/pymc4/distributions/__init__.py
+++ b/pymc4/distributions/__init__.py
@@ -1,8 +1,10 @@
-__backend = 'tensorflow'
+import os
 
-if __backend == 'base':
-    from .base import *
-elif __backend == 'tensorflow':
+_backend = 'tensorflow'
+if 'PYMC_BACKEND' in os.environ:
+    _backend = os.environ['PYMC_BACKEND']
+
+if _backend == 'tensorflow':
     from .tensorflow import *
 else:
     raise Exception('Backend %s not supported' % __backend)

--- a/pymc4/distributions/__init__.py
+++ b/pymc4/distributions/__init__.py
@@ -7,4 +7,4 @@ if 'PYMC_BACKEND' in os.environ:
 if _backend == 'tensorflow':
     from .tensorflow import *
 else:
-    raise Exception('Backend %s not supported' % __backend)
+    raise Exception('Backend %s not supported' % _backend)

--- a/pymc4/distributions/backend.py
+++ b/pymc4/distributions/backend.py
@@ -1,7 +1,0 @@
-"""Class defining different backends"""
-
-class AbstractBackend:
-    pass
-
-class TensorflowBackend(AbstractBackend):
-    pass

--- a/pymc4/distributions/backend.py
+++ b/pymc4/distributions/backend.py
@@ -1,0 +1,7 @@
+"""Class defining different backends"""
+
+class AbstractBackend:
+    pass
+
+class TensorflowBackend(AbstractBackend):
+    pass

--- a/pymc4/distributions/base/__init__.py
+++ b/pymc4/distributions/base/__init__.py
@@ -1,1 +1,2 @@
 from .distribution import Distribution, Potential
+from .continuous import Normal

--- a/pymc4/distributions/base/continuous.py
+++ b/pymc4/distributions/base/continuous.py
@@ -1,8 +1,7 @@
 """
 PyMC4 continuous random variables.
 
-Wraps selected tfp.distributions (listed in __all__) as pm.RandomVariables.
-Implements random variables not supported by tfp as distributions.
+Provides template classes for backend random variables.
 """
 
 # pylint: disable=undefined-all-variable
@@ -912,13 +911,6 @@ class Normal(ContinuousDistribution):
         @pm.model
         def model():
             x = pm.Normal('x', mu=0, sigma=10)
-
-    Developer Notes
-    ---------------
-    Parameter mappings to TensorFlow Probability are as follows:
-
-    - mu: loc
-    - sigma: scale
     """
 
     def __init__(self, name, mu, sigma, **kwargs):

--- a/pymc4/distributions/base/distribution.py
+++ b/pymc4/distributions/base/distribution.py
@@ -3,6 +3,7 @@ from ...coroutine_model import Model, unpack
 
 
 class Distribution(Model):
+    """Statistical distribution"""
     def __init__(self, name, keep_auxiliary=False, keep_return=True, transform=None, **kwargs):
         self.conditions = self.unpack_conditions(**kwargs)
         super().__init__(
@@ -12,6 +13,7 @@ class Distribution(Model):
             keep_auxiliary=keep_auxiliary,
         )
         self.transform = transform
+        self._init_backend()
 
     def unpack_distribution(self):
         return unpack(self)
@@ -23,6 +25,12 @@ class Distribution(Model):
         """
         return kwargs
 
+    @abc.abstractmethod
+    def _init_backend(self):
+        """Initialize the backend."""
+        pass
+
+    @abc.abstractmethod
     def sample(self, shape=(), seed=None):
         """
         Forward sampling implementation
@@ -36,6 +44,7 @@ class Distribution(Model):
         """
         raise NotImplementedError
 
+    @abc.abstractmethod
     def log_prob(self, value):
         raise NotImplementedError
 

--- a/pymc4/distributions/base/distribution.py
+++ b/pymc4/distributions/base/distribution.py
@@ -45,7 +45,28 @@ class Distribution(Model):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def sample_numpy(self, shape=(), seed=None):
+        """
+        Forward sampling implementation returning raw numpy arrays
+
+        Parameters
+        ----------
+        shape : tuple
+            sample shape
+        seed : int|None
+            random seed
+        Returns
+        ----------
+        array of given shape
+        """
+
+    @abc.abstractmethod
     def log_prob(self, value):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def log_prob_numpy(self, value):
+        """Return log probability in numpy array format"""
         raise NotImplementedError
 
 

--- a/pymc4/distributions/tensorflow/__init__.py
+++ b/pymc4/distributions/tensorflow/__init__.py
@@ -1,0 +1,1 @@
+from .continuous import Normal

--- a/pymc4/distributions/tensorflow/__init__.py
+++ b/pymc4/distributions/tensorflow/__init__.py
@@ -1,1 +1,2 @@
 from .continuous import Normal
+from .continuous import HalfNormal

--- a/pymc4/distributions/tensorflow/continuous.py
+++ b/pymc4/distributions/tensorflow/continuous.py
@@ -8,68 +8,14 @@ import tensorflow_probability as tfp
 tfd = tfp.distributions
 
 
-from .distribution import ContinuousDistribution
+from .distribution import BackendDistribution
+from ..base.continuous import Normal
 
 __all__ = ['Normal']
 
 
-class Normal(ContinuousDistribution):
+class Normal(BackendDistribution, Normal):
     r"""
-    Univariate normal random variable.
-
-    The pdf of this distribution is
-
-    .. math::
-
-       f(x \mid \mu, \tau) =
-           \sqrt{\frac{\tau}{2\pi}}
-           \exp\left\{ -\frac{\tau}{2} (x-\mu)^2 \right\}
-
-    Normal distribution can be parameterized either in terms of precision
-    or standard deviation. The link between the two parametrizations is
-    given by
-
-    .. math::
-
-       \tau = \dfrac{1}{\sigma^2}
-
-    .. plot::
-
-        import matplotlib.pyplot as plt
-        import numpy as np
-        import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
-        x = np.linspace(-5, 5, 1000)
-        mus = [0., 0., 0., -2.]
-        sigmas = [0.4, 1., 2., 0.4]
-        for mu, sigma in zip(mus, sigmas):
-            pdf = st.norm.pdf(x, mu, sigma)
-            plt.plot(x, pdf, label=r'$\mu$ = {}, $\sigma$ = {}'.format(mu, sigma))
-        plt.xlabel('x', fontsize=12)
-        plt.ylabel('f(x)', fontsize=12)
-        plt.legend(loc=1)
-        plt.show()
-
-    ========  ==========================================
-    Support   :math:`x \in \mathbb{R}`
-    Mean      :math:`\mu`
-    Variance  :math:`\dfrac{1}{\tau}` or :math:`\sigma^2`
-    ========  ==========================================
-
-    Parameters
-    ----------
-    mu : float
-        Mean.
-    sigma : float
-        Standard deviation (sigma > 0).
-
-    Examples
-    --------
-    .. code-block:: python
-        @pm.model
-        def model():
-            x = pm.Normal('x', mu=0, sigma=10)
-
     Developer Notes
     ---------------
     Parameter mappings to TensorFlow Probability are as follows:
@@ -77,21 +23,9 @@ class Normal(ContinuousDistribution):
     - mu: loc
     - sigma: scale
     """
-
-    def __init__(self, name, mu, sigma, **kwargs):
-        self.mu = mu
-        self.sigma = sigma
-        super().__init__(name, **kwargs)
-        self._init_backend()
+    __doc__ = Normal.__doc__ + __doc__
 
     def _init_backend(self):
-        self._backend_dist = tfd.Normal(
-            loc=self.mu, scale=self.sigma, name=self.name)
-
-    def sample(self, shape=(), seed=None):
-        return self._backend_dist.sample(shape, seed).numpy()
-
-    def log_prob(self, value):
-        return self._backend_dist.log_prob(value).numpy()
-
-
+        mu, sigma = self.conditions['mu'], self.conditions['sigma']
+        self._backend_distribution = tfd.Normal(
+            loc=mu, scale=sigma, name=self.name)

--- a/pymc4/distributions/tensorflow/continuous.py
+++ b/pymc4/distributions/tensorflow/continuous.py
@@ -1,0 +1,97 @@
+"""
+PyMC4 continuous random variables.
+
+Wraps selected tfp.distributions (listed in __all__) as pm.RandomVariables.
+Implements random variables not supported by tfp as distributions.
+"""
+import tensorflow_probability as tfp
+tfd = tfp.distributions
+
+
+from .distribution import ContinuousDistribution
+
+__all__ = ['Normal']
+
+
+class Normal(ContinuousDistribution):
+    r"""
+    Univariate normal random variable.
+
+    The pdf of this distribution is
+
+    .. math::
+
+       f(x \mid \mu, \tau) =
+           \sqrt{\frac{\tau}{2\pi}}
+           \exp\left\{ -\frac{\tau}{2} (x-\mu)^2 \right\}
+
+    Normal distribution can be parameterized either in terms of precision
+    or standard deviation. The link between the two parametrizations is
+    given by
+
+    .. math::
+
+       \tau = \dfrac{1}{\sigma^2}
+
+    .. plot::
+
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import scipy.stats as st
+        plt.style.use('seaborn-darkgrid')
+        x = np.linspace(-5, 5, 1000)
+        mus = [0., 0., 0., -2.]
+        sigmas = [0.4, 1., 2., 0.4]
+        for mu, sigma in zip(mus, sigmas):
+            pdf = st.norm.pdf(x, mu, sigma)
+            plt.plot(x, pdf, label=r'$\mu$ = {}, $\sigma$ = {}'.format(mu, sigma))
+        plt.xlabel('x', fontsize=12)
+        plt.ylabel('f(x)', fontsize=12)
+        plt.legend(loc=1)
+        plt.show()
+
+    ========  ==========================================
+    Support   :math:`x \in \mathbb{R}`
+    Mean      :math:`\mu`
+    Variance  :math:`\dfrac{1}{\tau}` or :math:`\sigma^2`
+    ========  ==========================================
+
+    Parameters
+    ----------
+    mu : float
+        Mean.
+    sigma : float
+        Standard deviation (sigma > 0).
+
+    Examples
+    --------
+    .. code-block:: python
+        @pm.model
+        def model():
+            x = pm.Normal('x', mu=0, sigma=10)
+
+    Developer Notes
+    ---------------
+    Parameter mappings to TensorFlow Probability are as follows:
+
+    - mu: loc
+    - sigma: scale
+    """
+
+    def __init__(self, name, mu, sigma, **kwargs):
+        self.mu = mu
+        self.sigma = sigma
+        super().__init__(name, **kwargs)
+        self._init_backend()
+
+    def _init_backend(self):
+        self._backend_dist = tfd.Normal(
+            loc=self.mu, scale=self.sigma, name=self.name)
+
+    def sample(self, shape=(), seed=None):
+        return self._backend_dist.sample(shape, seed).numpy()
+
+    def log_prob(self, value):
+        return self._backend_dist.log_prob(value).numpy()
+
+

--- a/pymc4/distributions/tensorflow/continuous.py
+++ b/pymc4/distributions/tensorflow/continuous.py
@@ -9,9 +9,9 @@ tfd = tfp.distributions
 
 
 from .distribution import BackendDistribution
-from ..base.continuous import Normal
+from ..base.continuous import Normal, HalfNormal
 
-__all__ = ['Normal']
+__all__ = ['Normal', 'HalfNormal']
 
 
 class Normal(BackendDistribution, Normal):
@@ -29,3 +29,18 @@ class Normal(BackendDistribution, Normal):
         mu, sigma = self.conditions['mu'], self.conditions['sigma']
         self._backend_distribution = tfd.Normal(
             loc=mu, scale=sigma, name=self.name)
+
+
+class HalfNormal(BackendDistribution, HalfNormal):
+    r"""
+    Developer Notes
+    ---------------
+    Parameter mappings to TensorFlow Probability are as follows:
+
+    - sigma: scale
+    """
+    __doc__ = HalfNormal.__doc__ + __doc__
+
+    def _init_backend(self):
+        sigma = self.conditions['sigma']
+        self._backend_distribution = tfd.HalfNormal(scale=sigma, name=self.name)

--- a/pymc4/distributions/tensorflow/distribution.py
+++ b/pymc4/distributions/tensorflow/distribution.py
@@ -7,17 +7,14 @@ class BackendDistribution(Distribution):
     """
     __doc__ = Distribution.__doc__ + __doc__
 
-    def sample(self, *args, **kwargs):
-        """
-        Returns
-        ---------
-        Tensor
-        """
-        return self._backend_distribution.sample(*args, **kwargs)
+    def sample(self, shape=(), seed=None):
+        return self._backend_distribution.sample(shape, seed)
 
-    def sample_numpy(self, *args, **kwargs):
-        """Return raw numpy format of sampling"""
-        return self.sample(*args, **kwargs).numpy()
+    def sample_numpy(self, shape=(), seed=None):
+        return self.sample(shape, seed).numpy()
 
     def log_prob(self, value):
         return self._backend_distribution.log_prob(value)
+
+    def log_prob_numpy(self, value):
+        return self.log_prob(value).numpy()

--- a/pymc4/distributions/tensorflow/distribution.py
+++ b/pymc4/distributions/tensorflow/distribution.py
@@ -1,66 +1,23 @@
-import abc
-from ...coroutine_model import Model, unpack
-from ..backend import TensorflowBackend
+from ..base.distribution import Distribution
 
 
-class Distribution(Model, TensorflowBackend):
+class BackendDistribution(Distribution):
+    """
+    BackendDistribution for Tensorflow distributions
+    """
+    __doc__ = Distribution.__doc__ + __doc__
 
-    def __init__(self,
-                 name,
-                 keep_auxiliary=False,
-                 keep_return=True,
-                 transform=None,
-                 **kwargs):
-        super().__init__(
-            self.unpack_distribution,
-            name=name,
-            keep_auxiliary=keep_auxiliary,
-            keep_return=keep_return,
-        )
-        self._init_backend()
-        pass
-
-    def unpack_distribution(self):
-        return unpack(self)
-
-    @abc.abstractmethod
-    def _init_backend(self):
-        pass
-
-    @abc.abstractmethod
-    def sample(self, shape=(), seed=None):
+    def sample(self, *args, **kwargs):
         """
-        Forward sampling implementation
-
-        Parameters
-        ----------
-        shape : tuple
-            sample shape
-        seed : int|None
-            random seed
         Returns
         ---------
-        array
+        Tensor
         """
-        raise NotImplementedError
+        return self._backend_distribution.sample(*args, **kwargs)
 
-    @abc.abstractmethod
+    def sample_numpy(self, *args, **kwargs):
+        """Return raw numpy format of sampling"""
+        return self.sample(*args, **kwargs).numpy()
+
     def log_prob(self, value):
-        raise NotImplementedError
-
-
-class ContinuousDistribution(Distribution):
-    """Base class for continuous distributions"""
-
-    def __init__(self,
-                 name,
-                 keep_auxiliary=False,
-                 keep_return=True,
-                 transform=None,
-                 *args,
-                 **kwargs):
-        super().__init__(
-            name=name,
-            keep_auxiliary=keep_auxiliary,
-            keep_return=keep_return,
-            **kwargs)
+        return self._backend_distribution.log_prob(value)

--- a/pymc4/distributions/tensorflow/distribution.py
+++ b/pymc4/distributions/tensorflow/distribution.py
@@ -1,0 +1,66 @@
+import abc
+from ...coroutine_model import Model, unpack
+from ..backend import TensorflowBackend
+
+
+class Distribution(Model, TensorflowBackend):
+
+    def __init__(self,
+                 name,
+                 keep_auxiliary=False,
+                 keep_return=True,
+                 transform=None,
+                 **kwargs):
+        super().__init__(
+            self.unpack_distribution,
+            name=name,
+            keep_auxiliary=keep_auxiliary,
+            keep_return=keep_return,
+        )
+        self._init_backend()
+        pass
+
+    def unpack_distribution(self):
+        return unpack(self)
+
+    @abc.abstractmethod
+    def _init_backend(self):
+        pass
+
+    @abc.abstractmethod
+    def sample(self, shape=(), seed=None):
+        """
+        Forward sampling implementation
+
+        Parameters
+        ----------
+        shape : tuple
+            sample shape
+        seed : int|None
+            random seed
+        Returns
+        ---------
+        array
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def log_prob(self, value):
+        raise NotImplementedError
+
+
+class ContinuousDistribution(Distribution):
+    """Base class for continuous distributions"""
+
+    def __init__(self,
+                 name,
+                 keep_auxiliary=False,
+                 keep_return=True,
+                 transform=None,
+                 *args,
+                 **kwargs):
+        super().__init__(
+            name=name,
+            keep_auxiliary=keep_auxiliary,
+            keep_return=keep_return,
+            **kwargs)


### PR DESCRIPTION
Added Normal distribution as an example.

```python
import pymc4.distributions as dist

n = dist.Normal(mu=0, sigma=1, name='n')
n.log_prob(3)   #-5.4189386
n.sample(5)  #returns 1-D numpy array of length 5
```

* Every distribution has an `_init_backend()` which does backend specific initialization. This way the wrapper doesn't need to override `__init__` for every backend
*  Assumes eager mode. tf-graph is not supported so far
* API is similar to tf-probability (`log_prob` and `sample`). Although this can be changed to be closer to PyMC3

* Every backend will have its own set of wrappers in `distributions/` ~~and its own `AbstractBackend` derived class.~~. EDIT: AbstractBackend has been removed for now. It can be easily added later.
* Every backend will have its own `BackendDistribution` class


TODO/goals
- [x] Backend is currently hardcoded  in `distributions/backend.py`. Add proper way to switch backends. EDIT: using `PYMC_BACKEND` environment variable like in Keras.
- [ ] Maintain state
- [x] Better mapping of arguments/keywords between PyMC4 and backends. Maybe use a dictionary to switch between the parameter mappings. EDIT: This has been implemented using `conditions` dictionary.
- [ ] Add more distributions


