### PR TITLE
Observed Variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ black:  # Format code in-place using black.
 	black pymc4/ tests/
 
 test:  # Test code using pytest.
-	pytest -v pymc4 tests --ignore=pymc4/hmc --doctest-modules --html=testing-report.html --self-contained-html
+	pytest -v pymc4 tests --doctest-modules --html=testing-report.html --self-contained-html
 
 lint: docstyle format style  # Lint code using pydocstyle, black and pylint.
 

--- a/pymc4/_backend/__init__.py
+++ b/pymc4/_backend/__init__.py
@@ -1,0 +1,21 @@
+import os
+from pymc4._backend.base import Backend
+
+ops: Backend  # to make type checkers happy
+SUPPORTED_BACKEND_NAMES = {"tensorflow"}
+TENSORFLOW = False
+
+BACKEND = "tensorflow"
+if "PYMC4_BACKEND" in os.environ:
+    BACKEND = os.environ["PYMC4_BACKEND"]
+
+if BACKEND == "tensorflow":
+    from .tensorflow import TensorflowBackend
+
+    ops = TensorflowBackend()
+    TENSORFLOW = True
+else:
+    raise ImportError(
+        "{} backend is not supported, please provide the supported one of {} "
+        "in PYMC4_BACKEND env variable.".format(BACKEND, SUPPORTED_BACKEND_NAMES)
+    )

--- a/pymc4/_backend/__init__.py
+++ b/pymc4/_backend/__init__.py
@@ -1,7 +1,10 @@
 import os
 from pymc4._backend.base import Backend
 
-ops: Backend  # to make type checkers happy
+
+__all__ = ["ops", "SUPPORTED_BACKEND_NAMES", "TENSORFLOW"]
+
+ops: Backend  # to make type checkers a bit more happy
 SUPPORTED_BACKEND_NAMES = {"tensorflow"}
 TENSORFLOW = False
 

--- a/pymc4/_backend/base.py
+++ b/pymc4/_backend/base.py
@@ -2,6 +2,8 @@ import abc
 import numpy as np
 from typing import TypeVar, Tuple, Union, Any, Type
 
+__all__ = ["Backend"]
+
 
 T = TypeVar("T")  # like a tensor dummy
 

--- a/pymc4/_backend/base.py
+++ b/pymc4/_backend/base.py
@@ -1,0 +1,32 @@
+import abc
+import numpy as np
+from typing import *
+
+
+T = TypeVar("T")  # like a tensor dummy
+
+
+class Backend(abc.ABC):
+    """
+    Abstract backend that defines common shared API for internal pymc4 needs.
+
+    The backend should not be used by directly by users as this creates too much teaching overhead.
+    Instead, this backend should be used by only the PyMC4 internals. The abstract base class ensures all
+    necessary functions are implemented and share same API. Please follow numpy API style for new functions if
+    you need them.
+    """
+
+    @staticmethod
+    @abc.abstractmethod
+    def sum(a: T, axis: Union[int, Tuple[int]] = None, keepdims=False) -> T:
+        ...
+
+    @staticmethod
+    @abc.abstractmethod
+    def numpy(a: T) -> np.ndarray:
+        ...
+
+    @staticmethod
+    @abc.abstractmethod
+    def tensor(a: Any, dtype: Type[np.dtype] = None) -> T:
+        ...

--- a/pymc4/_backend/base.py
+++ b/pymc4/_backend/base.py
@@ -1,6 +1,6 @@
 import abc
 import numpy as np
-from typing import *
+from typing import TypeVar, Tuple, Union, Any, Type
 
 
 T = TypeVar("T")  # like a tensor dummy

--- a/pymc4/_backend/tensorflow.py
+++ b/pymc4/_backend/tensorflow.py
@@ -1,7 +1,7 @@
 from pymc4._backend.base import Backend
 import tensorflow as tf
 import numpy as np
-from typing import *
+from typing import TypeVar, Tuple, Union, Any, Type
 
 T = TypeVar("T")
 

--- a/pymc4/_backend/tensorflow.py
+++ b/pymc4/_backend/tensorflow.py
@@ -3,6 +3,8 @@ import tensorflow as tf
 import numpy as np
 from typing import TypeVar, Tuple, Union, Any, Type
 
+__all__ = ["TensorflowBackend"]
+
 T = TypeVar("T")
 
 

--- a/pymc4/_backend/tensorflow.py
+++ b/pymc4/_backend/tensorflow.py
@@ -1,0 +1,20 @@
+from pymc4._backend.base import Backend
+import tensorflow as tf
+import numpy as np
+from typing import *
+
+T = TypeVar("T")
+
+
+class TensorflowBackend(Backend):
+    @staticmethod
+    def sum(a: T, axis: Union[int, Tuple[int]] = None, keepdims=False) -> T:
+        return tf.reduce_sum(a, axis=axis, keepdims=keepdims)
+
+    @staticmethod
+    def numpy(a: T) -> np.ndarray:
+        return a.numpy()
+
+    @staticmethod
+    def tensor(a: Any, dtype: Type[np.dtype] = None) -> T:
+        return tf.convert_to_tensor(a, dtype=dtype)

--- a/pymc4/coroutine_model.py
+++ b/pymc4/coroutine_model.py
@@ -40,15 +40,6 @@ def get_name(default, base_fn, name):
     return name
 
 
-def name2value(name):
-    if name is None:
-        return None
-    else:
-        if not isinstance(name, (int, str)):
-            raise ValueError("name should be either `str` or `int`, got type {}".format(type(name)))
-        return str(name)
-
-
 class ModelTemplate(object):
     """
     Model Template -- generative model with metadata.
@@ -181,7 +172,13 @@ class Model(object):
 
     def __init__(self, genfn, *, name=None, keep_auxiliary=True, keep_return=True):
         self.genfn = genfn
-        self.name = name2value(name)
+        if name is not None and not isinstance(name, (int, str)):
+            raise ValueError("name should be either `str` or `int`, got type {}".format(type(name)))
+        elif name is None:
+            self.name = None
+        else:
+            self.name = str(name)
+
         self.model_info = dict(
             keep_auxiliary=keep_auxiliary,
             keep_return=keep_return,

--- a/pymc4/coroutine_model.py
+++ b/pymc4/coroutine_model.py
@@ -46,7 +46,7 @@ def name2value(name):
     else:
         if not isinstance(name, (int, str)):
             raise ValueError("name should be either `str` or `int`, got type {}".format(type(name)))
-        return name
+        return str(name)
 
 
 class ModelTemplate(object):

--- a/pymc4/coroutine_model.py
+++ b/pymc4/coroutine_model.py
@@ -170,15 +170,18 @@ class Model(object):
         dict(keep_auxiliary=True, keep_return=False, scope=name_scope(None), name=None)
     )
 
-    def __init__(self, genfn, *, name=None, keep_auxiliary=True, keep_return=True):
-        self.genfn = genfn
+    @staticmethod
+    def validate_name(name):
         if name is not None and not isinstance(name, (int, str)):
             raise ValueError("name should be either `str` or `int`, got type {}".format(type(name)))
         elif name is None:
-            self.name = None
+            return None
         else:
-            self.name = str(name)
+            return str(name)
 
+    def __init__(self, genfn, *, name=None, keep_auxiliary=True, keep_return=True):
+        self.genfn = genfn
+        self.name = self.validate_name(name)
         self.model_info = dict(
             keep_auxiliary=keep_auxiliary,
             keep_return=keep_return,

--- a/pymc4/distributions/__init__.py
+++ b/pymc4/distributions/__init__.py
@@ -1,11 +1,7 @@
-import os
-from . import abstract
+from pymc4 import _backend
+from pymc4.distributions import abstract
 
-_backend = "tensorflow"
-if "PYMC_BACKEND" in os.environ:
-    _backend = os.environ["PYMC_BACKEND"]
-
-if _backend == "tensorflow":
+if _backend.TENSORFLOW:
     from .tensorflow import *  # pylint: disable=wildcard-import
 else:
-    raise ImportError("Backend {} not supported".format(_backend))
+    raise ImportError("Backend {} not supported".format(_backend.BACKEND))

--- a/pymc4/distributions/abstract/continuous.py
+++ b/pymc4/distributions/abstract/continuous.py
@@ -900,9 +900,9 @@ class Normal(ContinuousDistribution):
 
     Parameters
     ----------
-    mu : float
+    mu : float|tensor
         Mean.
-    sigma : float
+    sigma : float|tensor
         Standard deviation (sigma > 0).
 
     Examples
@@ -956,9 +956,9 @@ class Pareto(BoundedContinuousDistribution):
 
     Parameters
     ----------
-    alpha : float
+    alpha : float|tensor
         Shape parameter (alpha > 0).
-    m : float
+    m : float|tensor
         Scale parameter (m > 0).
 
     Developer Notes
@@ -1020,11 +1020,11 @@ class StudentT(ContinuousDistribution):
 
     Parameters
     ----------
-    nu : float
+    nu : float|tensor
         Degrees of freedom, also known as normality parameter (nu > 0).
-    mu : float
+    mu : float|tensor
         Location parameter.
-    sigma : float
+    sigma : float|tensor
         Scale parameter (sigma > 0). Converges to the standard deviation as nu
         increases. (only required if lam is not specified)
 
@@ -1095,11 +1095,11 @@ class Triangular(BoundedDistribution):
 
     Parameters
     ----------
-    lower : float
+    lower : float|tensor
         Lower limit.
-    c: float
+    c: float|tensor
         mode
-    upper : float
+    upper : float|tensor
         Upper limit.
 
     Developer Notes
@@ -1157,9 +1157,9 @@ class Uniform(BoundedContinuousDistribution):
 
     Parameters
     ----------
-    lower : float
+    lower : float|tensor
         Lower limit.
-    upper : float
+    upper : float|tensor
         Upper limit.
 
     Developer Notes
@@ -1218,9 +1218,9 @@ class VonMises(BoundedDistribution):
 
     Parameters
     ----------
-    mu : float
+    mu : float|tensor
         Mean.
-    kappa : float
+    kappa : float|tensor
         Concentration (\frac{1}{kappa} is analogous to \sigma^2).
 
     Developer Notes
@@ -1279,9 +1279,9 @@ class Weibull(PositiveContinuousDistribution):
 
     Parameters
     ----------
-    alpha : float
+    alpha : float|tensor
         Shape parameter (alpha > 0).
-    beta : float
+    beta : float|tensor
         Scale parameter (beta > 0).
 
     Developer Notes

--- a/pymc4/distributions/abstract/distribution.py
+++ b/pymc4/distributions/abstract/distribution.py
@@ -1,6 +1,9 @@
 import abc
 import copy
+from typing import Optional, Union
 from pymc4.coroutine_model import Model, unpack
+
+NameType = Union[str, int]
 
 
 class Distribution(Model):
@@ -9,7 +12,7 @@ class Distribution(Model):
     An abstract class with consistent API across backends
     """
 
-    def __init__(self, name, *, transform=None, observed=None, **kwargs):
+    def __init__(self, name: Optional[NameType], *, transform=None, observed=None, **kwargs):
         self.conditions = self.unpack_conditions(**kwargs)
         super().__init__(
             self.unpack_distribution, name=name, keep_return=True, keep_auxiliary=False
@@ -85,7 +88,7 @@ class Distribution(Model):
         """Create an anonymous Distribution that can't be used within yield statement."""
         return cls(None, *args, **kwargs)
 
-    def prior(self, name, *, transform=None, observed=None):
+    def prior(self, name: NameType, *, transform=None, observed=None):
         """Finalize instantiation of an anonymous Distribution.
 
         The resulting distribution will have the provided name, transform and an observed variable

--- a/pymc4/distributions/abstract/distribution.py
+++ b/pymc4/distributions/abstract/distribution.py
@@ -1,5 +1,4 @@
 import abc
-from typing import Any
 import copy
 from pymc4.coroutine_model import Model, unpack
 
@@ -83,15 +82,14 @@ class Distribution(Model):
 
     @classmethod
     def dist(cls, *args, **kwargs):
-        """
-        Create an anonymous Distribution that can't be used within yield statement
-        """
+        """Create an anonymous Distribution that can't be used within yield statement."""
         return cls(None, *args, **kwargs)
 
     def prior(self, name, *, transform=None, observed=None):
-        """
-        Finalize instantiation of an anonymous Distribution making it act as
-        a prior and allow to participate within yield
+        """Finalize instantiation of an anonymous Distribution.
+
+        The resulting distribution will have the provided name, transform and an observed variable
+        making it act as a prior and allow to participate within yield
         """
         if not self.is_anonymous:
             raise TypeError("Distribution is already not anonymous and cant define a new prior")

--- a/pymc4/distributions/abstract/distribution.py
+++ b/pymc4/distributions/abstract/distribution.py
@@ -103,7 +103,7 @@ class Distribution(Model):
         cloned_dist.conditions = cloned_dist.conditions.copy()
         if transform is not None:
             cloned_dist.transform = transform
-        cloned_dist.name = name
+        cloned_dist.name = cloned_dist.validate_name(name)
         return cloned_dist
 
     @property

--- a/pymc4/distributions/abstract/distribution.py
+++ b/pymc4/distributions/abstract/distribution.py
@@ -1,4 +1,6 @@
 import abc
+from typing import Any
+import copy
 from pymc4.coroutine_model import Model, unpack
 
 
@@ -8,14 +10,16 @@ class Distribution(Model):
     An abstract class with consistent API across backends
     """
 
-    def __init__(self, name, keep_auxiliary=False, keep_return=True, transform=None, **kwargs):
+    def __init__(self, name, *, transform=None, observed=None, **kwargs):
         self.conditions = self.unpack_conditions(**kwargs)
         super().__init__(
-            self.unpack_distribution,
-            name=name,
-            keep_return=keep_return,
-            keep_auxiliary=keep_auxiliary,
+            self.unpack_distribution, name=name, keep_return=True, keep_auxiliary=False
         )
+        if name is None and observed is not None:
+            raise ValueError(
+                "Observed variables are not allowed for anonymous (with name=None) Distributions"
+            )
+        self.model_info.update(observed=observed)
         self.transform = transform
         self._init_backend()
 
@@ -77,6 +81,41 @@ class Distribution(Model):
         """Return log probability in numpy array format."""
         raise NotImplementedError
 
+    @classmethod
+    def dist(cls, *args, **kwargs):
+        """
+        Create an anonymous Distribution that can't be used within yield statement
+        """
+        return cls(None, *args, **kwargs)
+
+    def prior(self, name, *, transform=None, observed=None):
+        """
+        Finalize instantiation of an anonymous Distribution making it act as
+        a prior and allow to participate within yield
+        """
+        if not self.is_anonymous:
+            raise TypeError("Distribution is already not anonymous and cant define a new prior")
+        if name is None:
+            raise ValueError("Can't create a prior Distribution without a name")
+        # internally is is ok to make a shallow copy of a distribution
+        cloned_dist = copy.copy(self)
+        # some mutable variables are required to be copied as well
+        cloned_dist.model_info = cloned_dist.model_info.copy()
+        cloned_dist.model_info.update(observed=observed)
+        cloned_dist.conditions = cloned_dist.conditions.copy()
+        if transform is not None:
+            cloned_dist.transform = transform
+        cloned_dist.name = name
+        return cloned_dist
+
+    @property
+    def is_anonymous(self):
+        return self.name is None
+
+    @property
+    def is_observed(self):
+        return self.model_info["observed"] is not None
+
 
 class ContinuousDistribution(Distribution):
     ...
@@ -132,22 +171,19 @@ class SimplexContinuousDistribution(ContinuousDistribution):
     ...
 
 
-class Potential(Distribution):
-    def __init__(self, value):
-        super().__init__(name=None)
-        self.value = value
+class Potential(object):
+    __slots__ = ("_value", "_coef")
 
-    def sample(self, shape=(), seed=None):
-        raise NotImplementedError("Unavailable for Potential")
+    def __init__(self, value, coef=1.0):
+        self._value = value
+        self._coef = coef
 
-    def sample_numpy(self, shape=(), seed=None):
-        raise NotImplementedError("Unavailable for Potential")
-
-    def log_prob(self, value):
-        raise NotImplementedError("Unavailable for Potential")
-
-    def log_prob_numpy(self, value):
-        raise NotImplementedError("Unavailable for Potential")
+    @property
+    def value(self):
+        if callable(self._value):
+            return self._value() * self._coef
+        else:
+            return self._value * self._coef
 
     @property
     @abc.abstractmethod

--- a/pymc4/distributions/tensorflow/continuous.py
+++ b/pymc4/distributions/tensorflow/continuous.py
@@ -29,7 +29,7 @@ class Normal(BackendDistribution, abstract.Normal):
 
     def _init_backend(self):
         mu, sigma = self.conditions["mu"], self.conditions["sigma"]
-        self._backend_distribution = tfd.Normal(loc=mu, scale=sigma, name=self.name)
+        self._backend_distribution = tfd.Normal(loc=mu, scale=sigma)
 
 
 class HalfNormal(BackendDistribution, abstract.HalfNormal):
@@ -46,4 +46,4 @@ class HalfNormal(BackendDistribution, abstract.HalfNormal):
 
     def _init_backend(self):
         sigma = self.conditions["sigma"]
-        self._backend_distribution = tfd.HalfNormal(scale=sigma, name=self.name)
+        self._backend_distribution = tfd.HalfNormal(scale=sigma)

--- a/pymc4/distributions/tensorflow/distribution.py
+++ b/pymc4/distributions/tensorflow/distribution.py
@@ -20,9 +20,6 @@ class BackendDistribution(Distribution):
 
 
 class Potential(BasePotential):
-    def _init_backend(self):
-        pass
-
     @property
     def value_numpy(self):
         return self.value.numpy()

--- a/pymc4/distributions/tensorflow/distribution.py
+++ b/pymc4/distributions/tensorflow/distribution.py
@@ -1,10 +1,11 @@
 from pymc4.distributions.abstract.distribution import Distribution, Potential as BasePotential
+from tensorflow_probability import distributions as tfd
 
 
 class BackendDistribution(Distribution):
     """Backend distribution for Tensorflow distributions."""
 
-    _backend_distribution = None
+    _backend_distribution: tfd.Distribution = None  # make type checkers happy
 
     def sample(self, shape=(), seed=None):
         return self._backend_distribution.sample(shape, seed)

--- a/pymc4/flow/executor.py
+++ b/pymc4/flow/executor.py
@@ -230,9 +230,15 @@ class SamplingExecutor(object):
     """
 
     def validate_return_object(self, return_object: Any):
-        if isinstance(return_object, coroutine_model.Model):
+        if isinstance(return_object, (coroutine_model.Model, types.GeneratorType, abstract.Potential)):
             raise EvaluationError(
-                "Return values should not contain instances of pm.coroutine_model.Model"
+                "Return values should not contain instances of "
+                "apm.coroutine_model.Model`, "
+                "`types.GeneratorType` "
+                "and `pm.distributions.Potential`. "
+                "To fix the error you should change the return statement to something like\n"
+                "    ..."
+                "    return (yield variable)"
             )
 
     def validate_return_value(self, return_value: Any):

--- a/pymc4/flow/executor.py
+++ b/pymc4/flow/executor.py
@@ -10,6 +10,8 @@ from pymc4.distributions import abstract
 
 
 ModelType = Union[types.GeneratorType, coroutine_model.Model]
+MODEL_TYPES = (types.GeneratorType, coroutine_model.Model)
+MODEL_AND_POTENTIAL_TYPES = (types.GeneratorType, coroutine_model.Model, abstract.Potential)
 
 
 class EvaluationError(RuntimeError):
@@ -231,7 +233,7 @@ class SamplingExecutor(object):
 
     def validate_return_object(self, return_object: Any):
         if isinstance(
-            return_object, (coroutine_model.Model, types.GeneratorType, abstract.Potential)
+            return_object, MODEL_AND_POTENTIAL_TYPES
         ):
             raise EvaluationError(
                 "Return values should not contain instances of "
@@ -382,7 +384,7 @@ class SamplingExecutor(object):
                 with model_info["scope"]:
                     dist = control_flow.send(return_value)
                     if not isinstance(
-                        dist, (types.GeneratorType, coroutine_model.Model, abstract.Potential)
+                        dist, MODEL_AND_POTENTIAL_TYPES
                     ):
                         # prohibit any unknown type
                         error = EvaluationError(
@@ -403,7 +405,7 @@ class SamplingExecutor(object):
                         except EvaluationError as error:
                             control_flow.throw(error)
                             raise StopExecution(StopExecution.NOT_HELD_ERROR_MESSAGE) from error
-                    elif isinstance(dist, (coroutine_model.Model, types.GeneratorType)):
+                    elif isinstance(dist, MODEL_TYPES):
                         return_value, state = self.evaluate_model(
                             dist, state=state, _validate_state=False
                         )

--- a/pymc4/flow/executor.py
+++ b/pymc4/flow/executor.py
@@ -343,7 +343,7 @@ class SamplingState(object):
         )
 
     def as_sampling_state(self):
-        """Sampling state that should me used within MCMC sampling.
+        """Create a sampling state that should me used within MCMC sampling.
 
         There are some principles that hold for the state.
 
@@ -362,10 +362,7 @@ class SamplingState(object):
         observed_values = dict()
         for name, dist in self.distributions.items():
             namespec = utils.NameParts.from_name(name)
-            if (
-                dist.transform is not None
-                and name not in self.observed_values
-            ):
+            if dist.transform is not None and name not in self.observed_values:
                 transformed_namespec = namespec.replace_transform(dist.transform.name)
                 if transformed_namespec.full_original_name not in self.transformed_values:
                     raise TypeError(

--- a/pymc4/flow/executor.py
+++ b/pymc4/flow/executor.py
@@ -1,7 +1,6 @@
 import types
 from typing import Any, Tuple, Dict, Union, List
 import collections
-import abc
 import itertools
 import pymc4 as pm
 from pymc4 import coroutine_model

--- a/pymc4/flow/executor.py
+++ b/pymc4/flow/executor.py
@@ -298,9 +298,11 @@ class SamplingState(object):
         ]
         # be less verbose here
         num_potentials = len(self.potentials)
-        indent = (len(self.__class__.__name__) + 1) * " "
+        indent = 4 * " "
         return (
-            "{}(untransformed_values: {}\n"
+            "{}(\n"
+            + indent
+            + "untransformed_values: {}\n"
             + indent
             + "transformed_values: {}\n"
             + indent

--- a/pymc4/flow/executor.py
+++ b/pymc4/flow/executor.py
@@ -232,9 +232,7 @@ class SamplingExecutor(object):
     """
 
     def validate_return_object(self, return_object: Any):
-        if isinstance(
-            return_object, MODEL_AND_POTENTIAL_TYPES
-        ):
+        if isinstance(return_object, MODEL_AND_POTENTIAL_TYPES):
             raise EvaluationError(
                 "Return values should not contain instances of "
                 "apm.coroutine_model.Model`, "
@@ -383,9 +381,7 @@ class SamplingExecutor(object):
             try:
                 with model_info["scope"]:
                     dist = control_flow.send(return_value)
-                    if not isinstance(
-                        dist, MODEL_AND_POTENTIAL_TYPES
-                    ):
+                    if not isinstance(dist, MODEL_AND_POTENTIAL_TYPES):
                         # prohibit any unknown type
                         error = EvaluationError(
                             "Type {} can't be processed in evaluation".format(type(dist))

--- a/pymc4/flow/executor.py
+++ b/pymc4/flow/executor.py
@@ -2,6 +2,7 @@ import types
 from typing import Any, Tuple, Dict, Union, List
 import collections
 import itertools
+from pymc4 import _backend
 import pymc4 as pm
 from pymc4 import coroutine_model
 from pymc4 import scopes
@@ -103,12 +104,11 @@ class SamplingState(object):
         self.potentials = potentials
 
     def collect_log_prob(self):
-        return sum(
-            itertools.chain(
-                (dist.log_prob(self.all_values[name]) for name, dist in self.distributions.items()),
-                (p.value for p in self.potentials),
-            )
+        all_terms = itertools.chain(
+            (dist.log_prob(self.all_values[name]) for name, dist in self.distributions.items()),
+            (p.value for p in self.potentials),
         )
+        return sum(map(_backend.ops.sum, all_terms))
 
     def __repr__(self):
         # display keys only

--- a/pymc4/flow/executor.py
+++ b/pymc4/flow/executor.py
@@ -14,14 +14,14 @@ ModelType = Union[types.GeneratorType, coroutine_model.Model]
 
 class EvaluationError(RuntimeError):
     # common error messages
-    OBSERVED_VARIABLE_IS_NOT_SUPPRESSED_BUT_ADDITIONAL_VALUE_PASSEED = (
+    OBSERVED_VARIABLE_IS_NOT_SUPPRESSED_BUT_ADDITIONAL_VALUE_PASSED = (
         "Attempting to evaluate a model with both "
         "observed and unobserved values provided "
         "what requires to choose what value to actually yield. "
         "To remove this error you either need to add `observed={{{0!r}: None}}` "
         "or remove {0!r} from untransformed values."
     )
-    OBSERVED_VARIABLE_IS_NOT_SUPPRESSED_BUT_ADDITIONAL_TRANSFORMED_VALUE_PASSEED = (
+    OBSERVED_VARIABLE_IS_NOT_SUPPRESSED_BUT_ADDITIONAL_TRANSFORMED_VALUE_PASSED = (
         "Attempting to evaluate a model with both "
         "observed and unobserved values provided "
         "what requires to choose what value to actually yield. "
@@ -480,7 +480,7 @@ class SamplingExecutor(object):
             else:
                 if scoped_name in state.untransformed_values:
                     raise EvaluationError(
-                        EvaluationError.OBSERVED_VARIABLE_IS_NOT_SUPPRESSED_BUT_ADDITIONAL_VALUE_PASSEED.format(
+                        EvaluationError.OBSERVED_VARIABLE_IS_NOT_SUPPRESSED_BUT_ADDITIONAL_VALUE_PASSED.format(
                             scoped_name
                         )
                     )

--- a/pymc4/flow/executor.py
+++ b/pymc4/flow/executor.py
@@ -242,10 +242,11 @@ class SamplingExecutor(object):
     def evaluate_model(
         self,
         model: ModelType,
-        *args: dict,
+        *,
         state: SamplingState = None,
         _validate_state: bool = True,
-        **kwargs: Any,
+        values: Dict[str, Any] = None,
+        observed: Dict[str, Any] = None,
     ) -> Tuple[Any, SamplingState]:
         # this will be dense with comments as all interesting stuff is composed in here
 
@@ -263,9 +264,9 @@ class SamplingExecutor(object):
         # as general as possible, just to restrict the imagination and reduce complexity.
 
         if state is None:
-            state = self.new_state(*args, **kwargs)
+            state = self.new_state(values=values, observed=observed)
         else:
-            if args or kwargs:
+            if values or observed:
                 raise ValueError("Provided arguments along with not empty state")
         if _validate_state:
             self.validate_state(state)

--- a/pymc4/flow/executor.py
+++ b/pymc4/flow/executor.py
@@ -129,24 +129,70 @@ class Executor(metaclass=abc.ABCMeta):
         #       in pymc4 it is model is some generator, that yields distributions and possibly returns a value
         #       at the point of posterior sampling we may want to skip some computations. This is
         #       mainly developer feature that allows to implement compositional distributions like Horseshoe and
-        #       at posterior predictive sampling omit some
+        #       at posterior predictive sampling omit some redundant parts of computational graph
         #   - keep_return
-        #       the return value of generator will be saved in state.values if this set to True. Usually it is what
-        #       we expect returning a value from a model.
+        #       the return value of generator will be saved in state.untransformed_values if this set to True.
         #   - observed
         #       the observed variable(s) for the given model. There are some restrictions on how do we provide
-        #       observed variables. First, every observed variable should have a name either explicitly or implicitly.
-        #       Explicit name is provided in case observed variable is a dictionary. That is related to
-        #       MultiObserved variables like in pymc3. MultiObserved variables were a special case of
-        #       regular variables and the decision to make it MultiObserved depended on the type of observed
-        #       user provided as data. Logp was computed then passing this dict to logp function. In contrast to pymc3
-        #       pymc4 has Model as a first class citizen and Distribution is just a subclass of it. Allowing passing
-        #       an observed variable to a Model sounds nice, but it breaks previous conventions (in pymc3) about
-        #       MultiObserved variables. Allowing passing observed to a Model sounds natural and explicit so far, but
-        #       this turns up with weird corner cases. An important one is a distribution MultiObserved data. It differs
-        #       from a model with separate distributions in a fundamental way as requires lop_prob arguments to be
-        #       packed in dictionary.
+        #       observed variables.
+        #       - Every observed variable should have a name either explicitly or implicitly.
+        #           The explicit way to provide an observed variable is to use `observed` keyword in a Distribution API
+        #           such as `Dist(..., observed=value)`. Observed variables are treated carefully in evaluation
+        #           what will be covered a bit later. The other way, a bit less explicit, is to provide a name
+        #           for the observed variable is creating a dictionary Dict[str, Any] that maps node names to
+        #           the observed values and provide it to the evaluator.
+        #       - Every distribution has to have only one value or none of them: either observed or (un)transformed one.
+        #           This constraint removes undefined choice and the need to guess for the intent.
+        #       Consequently, the above conventions create interesting situations that may appear in API usage.
+        #       As mentioned above, a distribution has to have only one value provided or none. Therefore we have to
+        #       perform a check at some point to make sure no ambiguous situations happen. The accepted cases should
+        #       then contain:
+        #       1. observed value is provided in `Dist(..., observed=value)`. This is the regular usage of PyMC4
+        #       2. observed value provided in `Dist(..., observed=value)` is suppressed. The case we perform
+        #           posterior/prior predictive checks. If the value is not suppressed, the executor will
+        #           yield the old value without sampling.
+        #       3. observed value provided in `Dist(..., observed=value)` is replaced with new data. The common case
+        #           of model being reused to fit for different datasets
+        #       4. unobserved value is provided in executor directly to replace an observed value.
+        #           An advanced usage of PyMC4 where we change the set of observed nodes (not variables)
         #
+        #       The above 4 cases should work with MCMC sampling engine and provide the correct log probability
+        #       computation from PyMC4 side. We should now recall that all the computation of log probability
+        #       is done in the transformed space, where parameters lie in Rn without any constraints.
+        #
+        #       The tempting questing is "what happens with the observed variables?". Without careful treatment
+        #       we would compute log probability for the transformed space if `Dist` in `Dist(..., observed=value)`
+        #       is bounded. But this is not required and redundant, the observed variable does not violate the bounds
+        #       and is not adjusted in MCMC. Therefore we should take care and not autotransfrom them in the transformed
+        #       Executor.
+        #
+        #       Some other issues may happen if we omit checks proceeding cases 1-4
+        #       Case 1. Nothing special here. We just make sure not to see the same value again in unobserved that is
+        #           probably a mistake.
+        #       Case 2. How do we know we need forward sample a particular observed node? The solution is to provide a
+        #           convention that passing `observed={"observed/variable/name": None}` suppresses an observed set as
+        #           `Dist(..., observed=value)` and instructs to sample from this distribution.
+        #       Case 3. That's probably explicit to pass `observed={"observed/variable/name": new_value}` to executor
+        #           and ask to replace the old observed
+        #       Case 4. Suppose we provide an observed value for a specific variable using `Dist(..., observed=value)`.
+        #           What should happen if we accidentally pass (un)transformed value to the executor with the same name?
+        #           Do we want to replace the observed value with a new one but not observed or it is a typo/mistake?
+        #           It may be very hard to track the intent except having a convention that we want to override the
+        #           value in here and perform inference on it. My (@ferrine'e) guess is that convention is very unsafe
+        #           and implicit, therefore I propose to additionally provide an intent suppressing the observed
+        #           variable by name. Actual code should contain `observed={"old/observed/variable/name": None}` passed
+        #           along with `values={"old/observed/variable/name": new_inference_value}` to the executor. We can be
+        #           sure there is no mistake and safely replace "old/observed/variable/name" with an unobserved one.
+        #
+        #       You may now see, that logic becomes quite complicated once we care about the details and common
+        #       use cases. So far we figured out what checks are to be performed, the next question is at what time they
+        #       are performed. In most cases we only get enough information at the time we actually see the node, not
+        #       before the execution, therefore there is not choice but to put all the execution validation at runtime.
+        #       These checks differ a bit for the transformed and untransformed variables as for the debug purposes
+        #       (we want to get the initial sampling state but bored in manually applying the transform) a provided
+        #       value for bounded distribution may be either in transformed or untransformed space. So far validation
+        #       logic is spread among different places, it probably worth unifying we way we validate execution state.
+
         if isinstance(model, abstract.Distribution):
             # usually happens when
             #   pm.evaluate_model(pm.distributions.Normal("n", 0, 1))

--- a/pymc4/flow/executor.py
+++ b/pymc4/flow/executor.py
@@ -230,7 +230,9 @@ class SamplingExecutor(object):
     """
 
     def validate_return_object(self, return_object: Any):
-        if isinstance(return_object, (coroutine_model.Model, types.GeneratorType, abstract.Potential)):
+        if isinstance(
+            return_object, (coroutine_model.Model, types.GeneratorType, abstract.Potential)
+        ):
             raise EvaluationError(
                 "Return values should not contain instances of "
                 "apm.coroutine_model.Model`, "

--- a/pymc4/flow/executor.py
+++ b/pymc4/flow/executor.py
@@ -1,14 +1,34 @@
 import types
-from typing import Any, Tuple
+from typing import Any, Tuple, Dict, Union, List
+import collections
 import abc
 import itertools
 import pymc4 as pm
+from pymc4 import coroutine_model
 from pymc4 import scopes
 from pymc4 import utils
 from pymc4.distributions import abstract
 
 
+ModelType = Union[types.GeneratorType, coroutine_model.Model]
+
+
 class EvaluationError(RuntimeError):
+    # common error messages
+    OBSERVED_VARIABLE_IS_NOT_SUPPRESSED_BUT_ADDITIONAL_VALUE_PASSEED = (
+        "Attempting to evaluate a model with both "
+        "observed and unobserved values provided "
+        "what requires to choose what value to actually yield. "
+        "To remove this error you either need to add `observed={{{0!r}: None}}` "
+        "or remove {0!r} from untransformed values."
+    )
+    OBSERVED_VARIABLE_IS_NOT_SUPPRESSED_BUT_ADDITIONAL_TRANSFORMED_VALUE_PASSEED = (
+        "Attempting to evaluate a model with both "
+        "observed and unobserved values provided "
+        "what requires to choose what value to actually yield. "
+        "To remove this error you either need to add `observed={{{0!r}: None}}` "
+        "or remove {1!r} from transformed values."
+    )
     ...
 
 
@@ -39,29 +59,106 @@ class Executor(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def proceed_distribution(self, dist, model_info, state):
+    def validate_state(self, state):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def modify_distribution(self, dist, model_info, state):
+    def proceed_distribution(
+        self, dist: abstract.Distribution, model_info: Dict[str, Any], state: Any
+    ):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def prepare_model_control_flow(self, model, model_info, state):
+    def modify_distribution(
+        self, dist: abstract.Distribution, model_info: Dict[str, Any], state: Any
+    ):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def finalize_control_flow(self, stop_iteration, model_info, state):
+    def prepare_model_control_flow(self, model: ModelType, model_info: Dict[str, Any], state: Any):
         raise NotImplementedError
 
-    def evaluate_model(self, model, *args, state=None, **kwargs):
+    @abc.abstractmethod
+    def finalize_control_flow(
+        self, stop_iteration: StopIteration, model_info: Dict[str, Any], state: Any
+    ):
+        raise NotImplementedError
+
+    @staticmethod
+    def validate_return_object(return_object: Any):
+        if isinstance(return_object, coroutine_model.Model):
+            raise EvaluationError(
+                "Return values should not contain instances of pm.coroutine_model.Model"
+            )
+
+    def validate_return_value(self, return_value: Any):
+        pm.utils.map_nested(self.validate_return_object, return_value)
+
+    def evaluate_model(
+        self, model: ModelType, *args, state=None, _validate_state=True, **kwargs
+    ) -> Tuple[Any, Any]:
+        # this will be dense with comments as all interesting stuff is composed in here
+
+        # 1) we need to check for state or generate one
+
+        #   in a state we might have:
+        #   - return values for distributions/models
+
+        # we will modify this state with:
+        #   - distributions, used to calculate logp correctly
+        #   - potentials, same purpose
+        #   - values in case we sample from a distribution
+
+        # All this is subclassed and implemented in Sampling Executor. This class tries to be
+        # as general as possible, just to restrict the imagination and reduce complexity.
+
         if state is None:
             state = self.new_state(*args, **kwargs)
         else:
             if args or kwargs:
                 raise ValueError("Provided arguments along with not empty state")
-        if isinstance(model, pm.coroutine_model.Model):
-            model_info = model.model_info()
+        if _validate_state:
+            self.validate_state(state)
+        # 2) we can proceed 2 typed of models:
+        #   - generator object that yields other model-like objects
+        #   - Model objects that come up with additional user provided information
+
+        # some words about "user provided information"
+        # they are:
+        #   - keep_auxiliary
+        #       in pymc4 it is model is some generator, that yields distributions and possibly returns a value
+        #       at the point of posterior sampling we may want to skip some computations. This is
+        #       mainly developer feature that allows to implement compositional distributions like Horseshoe and
+        #       at posterior predictive sampling omit some
+        #   - keep_return
+        #       the return value of generator will be saved in state.values if this set to True. Usually it is what
+        #       we expect returning a value from a model.
+        #   - observed
+        #       the observed variable(s) for the given model. There are some restrictions on how do we provide
+        #       observed variables. First, every observed variable should have a name either explicitly or implicitly.
+        #       Explicit name is provided in case observed variable is a dictionary. That is related to
+        #       MultiObserved variables like in pymc3. MultiObserved variables were a special case of
+        #       regular variables and the decision to make it MultiObserved depended on the type of observed
+        #       user provided as data. Logp was computed then passing this dict to logp function. In contrast to pymc3
+        #       pymc4 has Model as a first class citizen and Distribution is just a subclass of it. Allowing passing
+        #       an observed variable to a Model sounds nice, but it breaks previous conventions (in pymc3) about
+        #       MultiObserved variables. Allowing passing observed to a Model sounds natural and explicit so far, but
+        #       this turns up with weird corner cases. An important one is a distribution MultiObserved data. It differs
+        #       from a model with separate distributions in a fundamental way as requires lop_prob arguments to be
+        #       packed in dictionary.
+        #
+        if isinstance(model, abstract.Distribution):
+            # usually happens when
+            #   pm.evaluate_model(pm.distributions.Normal("n", 0, 1))
+            # is called
+            # we instead wrap it in an anonymous generator with single yield
+            # that sets the correct namespaces
+            # without it, we obtain values={"n/n": ...}
+            # However, we disallow return statements that are models
+            _model_ref = model
+            model = (lambda: (yield _model_ref))()
+        if isinstance(model, coroutine_model.Model):
+            model_info = model.model_info
             try:
                 control_flow = self.prepare_model_control_flow(model, model_info, state)
             except EarlyReturn as e:
@@ -71,15 +168,19 @@ class Executor(metaclass=abc.ABCMeta):
                 raise StopExecution(
                     "Attempting to call `evaluate_model` on a "
                     "non model-like object {}. Supported types are "
-                    "`types.GeneratorType` and `pm.coroutine_model.Model`"
+                    "`types.GeneratorType` and `pm.coroutine_model.Model`".format(type(model))
                 )
             control_flow = model
-            model_info = pm.coroutine_model.Model.default_model_info()
+            model_info = coroutine_model.Model.default_model_info
         return_value = None
         while True:
             try:
                 with model_info["scope"]:
                     dist = control_flow.send(return_value)
+                    if isinstance(dist, abstract.Potential):
+                        state.potentials.append(dist)
+                        return_value = dist
+                        continue
                     if isinstance(dist, abstract.Distribution):
                         dist = self.modify_distribution(dist, model_info, state)
                     if dist is None:
@@ -90,8 +191,10 @@ class Executor(metaclass=abc.ABCMeta):
                         except EvaluationError as error:
                             control_flow.throw(error)
                             raise StopExecution(StopExecution.NOT_HELD_ERROR_MESSAGE) from error
-                    elif isinstance(dist, (pm.coroutine_model.Model, types.GeneratorType)):
-                        return_value, state = self.evaluate_model(dist, state=state)
+                    elif isinstance(dist, (coroutine_model.Model, types.GeneratorType)):
+                        return_value, state = self.evaluate_model(
+                            dist, state=state, _validate_state=False
+                        )
                     else:
                         error = EvaluationError(
                             "Type of {} can't be processed in evaluation".format(dist)
@@ -120,6 +223,7 @@ class Executor(metaclass=abc.ABCMeta):
                 # e.g. in self.proceed_distribution
                 return e.args
             except StopIteration as stop_iteration:
+                self.validate_return_value(stop_iteration.args[:1])
                 return_value, state = self.finalize_control_flow(stop_iteration, model_info, state)
                 break
         return return_value, state
@@ -128,98 +232,196 @@ class Executor(metaclass=abc.ABCMeta):
 
 
 class SamplingState(object):
-    __slots__ = ("values", "distributions", "potentials")
+    __slots__ = (
+        "transformed_values",
+        "untransformed_values",
+        "observed_values",
+        "all_values",
+        "distributions",
+        "potentials",
+    )
 
-    def __init__(self, values: dict = None, distributions: dict = None, potentials: list = None):
-        if values is None:
-            values = dict()
+    def __init__(
+        self,
+        transformed_values: Dict[str, Any] = None,
+        untransformed_values: Dict[str, Any] = None,
+        observed_values: Dict[str, Any] = None,
+        distributions: Dict[str, abstract.Distribution] = None,
+        potentials: List[abstract.Potential] = None,
+    ):
+        # verbose __init__
+        if transformed_values is None:
+            transformed_values = dict()
+        else:
+            transformed_values = transformed_values.copy()
+        if untransformed_values is None:
+            untransformed_values = dict()
+        else:
+            untransformed_values = untransformed_values.copy()
+        if observed_values is None:
+            observed_values = dict()
+        else:
+            observed_values = observed_values.copy()
         if distributions is None:
             distributions = dict()
+        else:
+            distributions = distributions.copy()
         if potentials is None:
             potentials = list()
-        self.values = values
+        else:
+            potentials = potentials.copy()
+        self.transformed_values = transformed_values
+        self.untransformed_values = untransformed_values
+        self.observed_values = observed_values
+        self.all_values = collections.ChainMap(
+            self.untransformed_values, self.transformed_values, self.observed_values
+        )
         self.distributions = distributions
         self.potentials = potentials
-
-    @property
-    def transformed_values(self):
-        all_values: dict = self.values.copy()
-        # get rid of `nest/name` if `nest/__transform_name` is present
-        for fullname in self.values:
-            namespec = utils.NameParts(fullname)
-            if namespec.is_transformed:
-                if namespec.full_untransformed_name in all_values:
-                    all_values.pop(namespec.full_untransformed_name)
-        return all_values
-
-    @property
-    def untransformed_values(self):
-        all_values: dict = self.values.copy()
-        # get rid of `nest/__transform_name` if `nest/name` is present
-        for fullname in self.values:
-            namespec = utils.NameParts(fullname)
-            if namespec.is_transformed:
-                all_values.pop(namespec.full_original_name)
-        return all_values
-
-    def new_state_with_untransformed(self):
-        return self.__class__(
-            values=self.untransformed_values, distributions=dict(), potentials=list()
-        )
-
-    def new_state_with_transformed(self):
-        return self.__class__(
-            values=self.transformed_values, distributions=dict(), potentials=list()
-        )
-
-    @classmethod
-    def new(cls, *conditions: dict, **condition_kwargs: dict):
-        condition_state = utils.merge_dicts(*conditions, condition_kwargs)
-        return cls(values=condition_state, distributions=dict(), potentials=[])
 
     def collect_log_prob(self):
         return sum(
             itertools.chain(
-                (dist.log_prob(self.values[name]) for name, dist in self.distributions.items()),
+                (dist.log_prob(self.all_values[name]) for name, dist in self.distributions.items()),
                 (p.value for p in self.potentials),
             )
         )
 
     def __repr__(self):
         # display keys only
-        values = list(self.values)
+        untransformed_values = list(self.untransformed_values)
+        transformed_values = list(self.transformed_values)
+        observed_values = list(self.observed_values)
         # format like dist:name
         distributions = [
             "{}:{}".format(d.__class__.__name__, k) for k, d in self.distributions.items()
         ]
         # be less verbose here
         num_potentials = len(self.potentials)
-        return "{}(\n    values: {}\n    distributions: {}\n    num_potentials={}\n)".format(
-            self.__class__.__name__, values, distributions, num_potentials
+        indent = (len(self.__class__.__name__) + 1) * " "
+        return (
+            "{}(untransformed_values: {}\n"
+            + indent
+            + "transformed_values: {}\n"
+            + indent
+            + "observed_values: {}\n"
+            + indent
+            + "distributions: {}\n"
+            + indent
+            + "num_potentials={})"
+        ).format(
+            self.__class__.__name__,
+            untransformed_values,
+            transformed_values,
+            observed_values,
+            distributions,
+            num_potentials,
+        )
+
+    @classmethod
+    def from_values(cls, values: Dict[str, Any] = None, observed_values: Dict[str, Any] = None):
+        if values is None:
+            return cls(observed_values=observed_values)
+        transformed_values = dict()
+        untransformed_values = dict()
+        # split by `nest/name` or `nest/__transform_name`
+        for fullname in values:
+            namespec = utils.NameParts.from_name(fullname)
+            if namespec.is_transformed:
+                transformed_values[fullname] = values[fullname]
+            else:
+                untransformed_values[fullname] = values[fullname]
+        return cls(transformed_values, untransformed_values, observed_values)
+
+    def clone(self):
+        return self.__class__(
+            transformed_values=self.transformed_values,
+            untransformed_values=self.untransformed_values,
+            observed_values=self.observed_values,
+            distributions=self.distributions,
+            potentials=self.potentials,
+        )
+
+    def as_sampling_state(self):
+        """Sampling state that should me used within MCMC sampling.
+
+        There are some principles that hold for the state.
+
+            1. Check there is at least one distribution
+            2. Check all transformed distributions are autotransformed
+            3. Remove untransformed values if transformed are present
+            4. Remove all other irrelevant values
+        """
+        if not self.distributions:
+            raise TypeError(
+                "No distributions found in the state. "
+                "the model you evaluated is empty and does not yield any PyMC4 distribution"
+            )
+        untransformed_values = dict()
+        transformed_values = dict()
+        observed_values = dict()
+        for name, dist in self.distributions.items():
+            namespec = utils.NameParts.from_name(name)
+            if (
+                dist.transform is not None
+                and name not in self.observed_values
+            ):
+                transformed_namespec = namespec.replace_transform(dist.transform.name)
+                if transformed_namespec.full_original_name not in self.transformed_values:
+                    raise TypeError(
+                        "Transformed value {!r} is not found for {} distribution with name {!r}. "
+                        "You should evaluate the model using the transformed executor to get "
+                        "the correct sampling state.".format(
+                            transformed_namespec.full_original_name, dist, name
+                        )
+                    )
+                else:
+                    transformed_values[
+                        transformed_namespec.full_original_name
+                    ] = self.transformed_values[transformed_namespec.full_original_name]
+            else:
+                if name in self.observed_values:
+                    observed_values[name] = self.observed_values[name]
+                elif name in self.untransformed_values:
+                    untransformed_values[name] = self.untransformed_values[name]
+                else:
+                    raise TypeError(
+                        "{} distribution with name {!r} does not have the corresponding value "
+                        "in the state. This may happen if the current "
+                        "state was modified in the wrong way."
+                    )
+        return self.__class__(
+            transformed_values=transformed_values,
+            untransformed_values=untransformed_values,
+            observed_values=observed_values,
         )
 
 
 class SamplingExecutor(Executor):
-    def __init__(self, *conditions: dict, **condition_kwargs: dict):
-        self.default_condition = utils.merge_dicts(*conditions, condition_kwargs)
+    def new_state(self, state=None, values: Dict[str, Any] = None, observed: Dict[str, Any] = None):
+        return SamplingState.from_values(values=values, observed_values=observed)
 
-    def new_state(self, *conditions: dict, **condition_kwargs: dict):
-        condition_state = self.default_condition.copy()
-        return SamplingState.new(condition_state, condition_kwargs, *conditions)
+    def validate_state(self, state):
+        if state.transformed_values:
+            raise ValueError(
+                "untransformed executor should not contain "
+                "transformed variables but found {}".format(set(state.transformed_values))
+            )
 
-    def modify_distribution(self, dist, model_info, state):
+    def modify_distribution(
+        self, dist: abstract.Distribution, model_info: Dict[str, Any], state: SamplingState
+    ):
         return dist
 
-    def proceed_distribution(self, dist, model_info, state):
-        if isinstance(dist, abstract.Potential):
-            value = dist.value
-            state.potentials.append(dist)
-            return value, state
-
+    def proceed_distribution(
+        self, dist: abstract.Distribution, model_info: Dict[str, Any], state: SamplingState
+    ):
+        if dist.is_anonymous:
+            raise EvaluationError("Attempting to create an anonymous Distribution")
         scoped_name = scopes.variable_name(dist.name)
         if scoped_name in state.distributions:
             raise EvaluationError(
-                "Attempting to create a duplicate variable '{}', "
+                "Attempting to create a duplicate variable {!r}, "
                 "this may happen if you forget to use `pm.name_scope()` when calling same "
                 "model/function twice without providing explicit names. If you see this "
                 "error message and the function being called is not wrapped with "
@@ -227,40 +429,72 @@ class SamplingExecutor(Executor):
                     scoped_name
                 )
             )
-        if scoped_name in state.values:
-            return_value = state.values[scoped_name]
+        if scoped_name in state.observed_values or dist.is_observed:
+            observed_variable = observed_value_in_evaluation(scoped_name, dist, state)
+            if observed_variable is None:
+                # None indicates we pass None to the state.observed_values dict,
+                # might be posterior predictive or programmatically override to exchange observed variable to latent
+                if scoped_name not in state.untransformed_values:
+                    # posterior predictive
+                    return_value = state.untransformed_values[scoped_name] = dist.sample()
+                else:
+                    # replace observed variable with a custom one
+                    return_value = state.untransformed_values[scoped_name]
+                state.observed_values.pop(scoped_name)
+            else:
+                if scoped_name in state.untransformed_values:
+                    raise EvaluationError(
+                        EvaluationError.OBSERVED_VARIABLE_IS_NOT_SUPPRESSED_BUT_ADDITIONAL_VALUE_PASSEED.format(
+                            scoped_name
+                        )
+                    )
+                return_value = state.observed_values[scoped_name] = observed_variable
+        elif scoped_name in state.untransformed_values:
+            return_value = state.untransformed_values[scoped_name]
         else:
-            return_value = state.values[scoped_name] = dist.sample()
+            return_value = state.untransformed_values[scoped_name] = dist.sample()
         state.distributions[scoped_name] = dist
         return return_value, state
 
-    def prepare_model_control_flow(self, model, model_info, state):
+    def prepare_model_control_flow(
+        self, model: coroutine_model.Model, model_info: Dict[str, Any], state: SamplingState
+    ):
         control_flow: types.GeneratorType = model.control_flow()
         model_name = model_info["name"]
         if model_name is None and model_info["keep_return"]:
-            error = EvaluationError("Attempting to create unnamed variable")
+            error = EvaluationError(
+                "Attempting to create unnamed return variable when `keep_return` is set to True"
+            )
             control_flow.throw(error)
             control_flow.close()
             raise StopExecution(StopExecution.NOT_HELD_ERROR_MESSAGE) from error
         return_name = scopes.variable_name(model_name)
-        if not model_info["keep_auxiliary"] and return_name in state.values:
-            raise EarlyReturn(state.values[model_name], state)
+        if not model_info["keep_auxiliary"] and return_name in state.untransformed_values:
+            raise EarlyReturn(state.untransformed_values[model_name], state)
         return control_flow
 
-    def finalize_control_flow(self, stop_iteration, model_info, state):
+    def finalize_control_flow(
+        self, stop_iteration: StopIteration, model_info: Dict[str, Any], state: SamplingState
+    ):
         if stop_iteration.args:
             return_value = stop_iteration.args[0]
         else:
             return_value = None
         if return_value is not None and model_info["keep_return"]:
+            # we should filter out allowed return types, but this is totally backend
+            # specific and should be determined at import time.
             return_name = scopes.variable_name(model_info["name"])
-            state.values[return_name] = return_value
+            state.untransformed_values[return_name] = return_value
         return return_value, state
 
     # just to make type checkers happy
     def evaluate_model(
-        self, model, *args: dict, state: SamplingState = None, **kwargs
+        self, model: ModelType, *args: dict, state: SamplingState = None, **kwargs: Any
     ) -> Tuple[Any, SamplingState]:
         return super().evaluate_model(model, *args, state=state, **kwargs)
 
     __call__ = evaluate_model
+
+
+def observed_value_in_evaluation(scoped_name, dist, state):
+    return state.observed_values.get(scoped_name, dist.model_info["observed"])

--- a/pymc4/flow/transformed_executor.py
+++ b/pymc4/flow/transformed_executor.py
@@ -82,7 +82,7 @@ class TransformedSamplingExecutor(SamplingExecutor):
                 # 2. here decide on logdet computation, this might be effective
                 # with transformed value, but not with an untransformed one
                 # this information is stored in transform.jacobian_preference class attribute
-                # we pospone the computation of logdet as it might have some overhead
+                # we postpone the computation of logdet as it might have some overhead
                 if transform.jacobian_preference == JacobianPreference.Forward:
                     potential_fn = functools.partial(
                         transform.jacobian_log_det, untransformed_value

--- a/pymc4/flow/transformed_executor.py
+++ b/pymc4/flow/transformed_executor.py
@@ -6,7 +6,8 @@ from pymc4.flow.executor import SamplingExecutor, EvaluationError, observed_valu
 
 
 class TransformedSamplingExecutor(SamplingExecutor):
-    def validate_state(self, state):
+    @staticmethod
+    def validate_state(state):
         return
 
     def modify_distribution(self, dist, model_info, state):

--- a/pymc4/flow/transformed_executor.py
+++ b/pymc4/flow/transformed_executor.py
@@ -6,8 +6,7 @@ from pymc4.flow.executor import SamplingExecutor, EvaluationError, observed_valu
 
 
 class TransformedSamplingExecutor(SamplingExecutor):
-    @staticmethod
-    def validate_state(state):
+    def validate_state(self, state):
         return
 
     def modify_distribution(self, dist, model_info, state):

--- a/pymc4/flow/transformed_executor.py
+++ b/pymc4/flow/transformed_executor.py
@@ -32,13 +32,13 @@ class TransformedSamplingExecutor(SamplingExecutor):
             # but raise if we have transformed value passed in dict
             if transformed_scoped_name in state.transformed_values:
                 raise EvaluationError(
-                    EvaluationError.OBSERVED_VARIABLE_IS_NOT_SUPPRESSED_BUT_ADDITIONAL_TRANSFORMED_VALUE_PASSEED.format(
+                    EvaluationError.OBSERVED_VARIABLE_IS_NOT_SUPPRESSED_BUT_ADDITIONAL_TRANSFORMED_VALUE_PASSED.format(
                         scoped_name, transformed_scoped_name
                     )
                 )
             if scoped_name in state.untransformed_values:
                 raise EvaluationError(
-                    EvaluationError.OBSERVED_VARIABLE_IS_NOT_SUPPRESSED_BUT_ADDITIONAL_VALUE_PASSEED.format(
+                    EvaluationError.OBSERVED_VARIABLE_IS_NOT_SUPPRESSED_BUT_ADDITIONAL_VALUE_PASSED.format(
                         scoped_name, scoped_name
                     )
                 )

--- a/pymc4/flow/transformed_executor.py
+++ b/pymc4/flow/transformed_executor.py
@@ -1,30 +1,56 @@
-import copy
-
+import functools
 from pymc4 import scopes, distributions
 from pymc4.distributions import abstract
 from pymc4.distributions.abstract.transforms import JacobianPreference
-from pymc4.flow.executor import SamplingExecutor, EvaluationError
+from pymc4.flow.executor import SamplingExecutor, EvaluationError, observed_value_in_evaluation
 
 
 class TransformedSamplingExecutor(SamplingExecutor):
+    def validate_state(self, state):
+        return
+
     def modify_distribution(self, dist, model_info, state):
         dist = super().modify_distribution(dist, model_info, state)
         if not isinstance(dist, abstract.Distribution):
             return dist
-        # this will be mentioned later, that's the way to avoid loops
-        if dist.transform is None:
+        scoped_name = scopes.variable_name(dist.name)
+
+        if dist.transform is None or dist.model_info.get(  # do nothing else if no transform is set
+            "autotransformed", False
+        ):  # already autotransformed, do nothing else
             return dist
         transform = dist.transform
-        scoped_name = scopes.variable_name(dist.name)
         transformed_scoped_name = scopes.variable_name(
             # double underscore stands for transform
             "__{}_{}".format(transform.name, dist.name)
         )
-        if transformed_scoped_name in state.values or scoped_name in state.values:
+        if observed_value_in_evaluation(scoped_name, dist, state) is not None:
+            # do not modify a distribution if it is observed
+            # same for programmatically observed
+            # but not for programmatically set to unobserved (when value is None)
+            # but raise if we have transformed value passed in dict
+            if transformed_scoped_name in state.transformed_values:
+                raise EvaluationError(
+                    EvaluationError.OBSERVED_VARIABLE_IS_NOT_SUPPRESSED_BUT_ADDITIONAL_TRANSFORMED_VALUE_PASSEED.format(
+                        scoped_name, transformed_scoped_name
+                    )
+                )
+            if scoped_name in state.untransformed_values:
+                raise EvaluationError(
+                    EvaluationError.OBSERVED_VARIABLE_IS_NOT_SUPPRESSED_BUT_ADDITIONAL_VALUE_PASSEED.format(
+                        scoped_name, scoped_name
+                    )
+                )
+            return dist
+
+        if transformed_scoped_name in state.transformed_values:
             # We do not sample in this if branch
 
             # 0. do not allow ambiguity in state, make sure only one value is provided to compute logp
-            if transformed_scoped_name in state.values and scoped_name in state.values:
+            if (
+                transformed_scoped_name in state.transformed_values
+                and scoped_name in state.untransformed_values
+            ):
                 raise EvaluationError(
                     "Found both transformed and untransformed variables in the state: "
                     "'{} and '{}', but need exactly one".format(
@@ -34,15 +60,15 @@ class TransformedSamplingExecutor(SamplingExecutor):
 
             def model():
                 # 1. now compute all the variables: in the transformed and untransformed space
-                if transformed_scoped_name in state.values:
-                    transformed_value = state.values[transformed_scoped_name]
+                if transformed_scoped_name in state.transformed_values:
+                    transformed_value = state.transformed_values[transformed_scoped_name]
                     untransformed_value = transform.backward(transformed_value)
                 else:
-                    untransformed_value = state.values[scoped_name]
+                    untransformed_value = state.untransformed_values[scoped_name]
                     transformed_value = transform.forward(untransformed_value)
                 # these lines below
-                state.values[scoped_name] = untransformed_value
-                state.values[transformed_scoped_name] = transformed_value
+                state.untransformed_values[scoped_name] = untransformed_value
+                state.transformed_values[transformed_scoped_name] = transformed_value
                 # disable sampling and save cached results to store for yield dist
 
                 # once we are done with variables we can yield the value in untransformed space
@@ -50,47 +76,54 @@ class TransformedSamplingExecutor(SamplingExecutor):
 
                 # Important:
                 # I have no idea yet, how to make that beautiful.
-                # Here we remove a transform to create another model that
-                # essentially has an untransformed predefined value and the potential
-                # needed to specify the logp properly
-                dist_no_transform = copy.copy(dist)
-                dist_no_transform.transform = None
-                # If we do not set transform to None we will appear here again and again ending
-                # up with an unclosed recursion
+                # Here we indicate the distribution is already autotransformed nto to get in the infinite loop
+                dist.model_info["autotransformed"] = True
 
                 # 2. here decide on logdet computation, this might be effective
                 # with transformed value, but not with an untransformed one
                 # this information is stored in transform.jacobian_preference class attribute
+                # we pospone the computation of logdet as it might have some overhead
                 if transform.jacobian_preference == JacobianPreference.Forward:
-                    potential = -transform.jacobian_log_det(untransformed_value)
+                    potential_fn = functools.partial(
+                        transform.jacobian_log_det, untransformed_value
+                    )
+                    coef = -1.0
                 else:
-                    potential = transform.inverse_jacobian_log_det(transformed_value)
-                yield distributions.Potential(potential)
+                    potential_fn = functools.partial(
+                        transform.inverse_jacobian_log_det, transformed_value
+                    )
+                    coef = 1.0
+                yield distributions.Potential(potential_fn, coef=coef)
                 # 3. final return+yield will return untransformed_value
                 # as it is stored in state.values
                 # Note: we need yield here to make another checks on name duplicates, etc
-                return (yield dist_no_transform)
+                return (yield dist)
 
         else:
             # we gonna sample here, but logp should be computed for the transformed space
             def model():
-                # 0. as explained above we make a shallow copy of the distribution and remove the transform
-                dist_no_transform = copy.copy(dist)
-                dist_no_transform.transform = None
+                # 0. as explained above we indicate we already performed autotransform
+                dist.model_info["autotransformed"] = True
                 # 1. sample a value, as we've checked there is no state provided
-                # we need transform = None here not to get in a trouble
+                # we need `dist.model_info["autotransformed"] = True` here not to get in a trouble
                 # the return value is not yet user facing
-                sampled_untransformed_value = yield dist_no_transform
+                sampled_untransformed_value = yield dist
                 sampled_transformed_value = transform.forward(sampled_untransformed_value)
                 # already stored untransformed value via yield
                 # state.values[scoped_name] = sampled_untransformed_value
-                state.values[transformed_scoped_name] = sampled_transformed_value
+                state.transformed_values[transformed_scoped_name] = sampled_transformed_value
                 # 2. increment the potential
                 if transform.jacobian_preference == JacobianPreference.Forward:
-                    potential = -transform.jacobian_log_det(sampled_untransformed_value)
+                    potential_fn = functools.partial(
+                        transform.jacobian_log_det, sampled_untransformed_value
+                    )
+                    coef = -1.0
                 else:
-                    potential = transform.inverse_jacobian_log_det(sampled_transformed_value)
-                yield distributions.Potential(potential)
+                    potential_fn = functools.partial(
+                        transform.inverse_jacobian_log_det, sampled_transformed_value
+                    )
+                    coef = 1.0
+                yield distributions.Potential(potential_fn, coef=coef)
                 # 3. return value to the user
                 return sampled_untransformed_value
 

--- a/pymc4/scopes.py
+++ b/pymc4/scopes.py
@@ -55,7 +55,8 @@ class Scope(object):
                 else:
                     yield val
         if leaf is not cls._leaf:
-            yield leaf
+            if not (drop_none and leaf is None):
+                yield leaf
 
     @classmethod
     def variable_name(cls, name):
@@ -80,8 +81,16 @@ class Scope(object):
         ...     with Scope():
         ...         print(Scope.variable_name("leaf1"))
         inner/leaf1
+
+        empty name results in None name
+        >>> assert Scope.variable_name(None) is None
+        >>> assert Scope.variable_name("") is None
         """
-        return "/".join(map(str, cls.chain("name", leaf=name, drop_none=True)))
+        value = "/".join(map(str, cls.chain("name", leaf=name, drop_none=True)))
+        if not value:
+            return None
+        else:
+            return value
 
     def __repr__(self):
         return "Scope({})".format(self.__dict__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tf-nightly-2.0-preview
+tf-nightly-2.0-preview==2.0.0-dev20190704
 tfp-nightly
 pymc3
 scipy

--- a/scripts/container.sh
+++ b/scripts/container.sh
@@ -19,5 +19,5 @@ fi
 if [[ $* == *--test* ]]; then
     echo "Testing PyMC4"
     docker run --mount type=bind,source="$(pwd)",target=/opt/pymc4/ pymc4:latest bash -c \
-                                      "pytest -v pymc4/tests/ --cov=pymc4/"
+                                      "pytest -v pymc4 tests --doctest-modules --cov=pymc4/"
 fi

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -385,3 +385,21 @@ def test_unnamed_return_2():
     with pytest.raises(pm.flow.executor.EvaluationError) as e:
         pm.evaluate_model_transformed(a_model())
     assert e.match("unnamed")
+
+
+def test_uncatched_exception_works():
+    @pm.model
+    def a_model():
+        try:
+            yield 1
+        except:
+            pass
+        yield pm.distributions.HalfNormal("n", 1, transform=pm.distributions.transforms.Log())
+
+    with pytest.raises(pm.flow.executor.StopExecution) as e:
+        pm.evaluate_model(a_model())
+    assert e.match("something_bad")
+
+    with pytest.raises(pm.flow.executor.StopExecution) as e:
+        pm.evaluate_model_transformed(a_model())
+    assert e.match("something_bad")

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -413,3 +413,12 @@ def test_none_yield():
     with pytest.raises(pm.flow.executor.EvaluationError) as e:
         pm.evaluate_model_transformed(model())
     assert e.match("processed in evaluation")
+
+
+def test_differently_shaped_logp():
+    def model():
+        yield dist.Normal("n1", np.zeros(10), np.ones(10))
+        yield dist.Normal("n2", np.zeros(3), np.ones(3))
+
+    _, state = pm.evaluate_model(model())
+    state.collect_log_prob()  # this should work

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -5,41 +5,11 @@ import numpy as np
 from pymc4 import distributions as dist
 
 
-def test_simple_model():
-    def simple_model():
-        norm = yield dist.Normal("n", 0, 1)
-        return norm
-
-    _, state = pm.evaluate_model(simple_model())
-    assert "n" in state.values
-
-
-def test_complex_model():
+@pytest.fixture("module")
+def complex_model():
     @pm.model
     def nested_model(cond):
-        norm = yield dist.Normal("n", cond, 1)
-        return norm
-
-    @pm.model
-    def complex_model():
-        norm = yield dist.Normal("n", 0, 1)
-        result = yield nested_model(norm, name="a")
-        return result
-
-    _, state = pm.evaluate_model(complex_model())
-
-    assert set(state.values) == {
-        "complex_model/n",
-        "complex_model/a",
-        "complex_model/a/n",
-        "complex_model",
-    }
-
-
-def test_complex_model_no_keep_return():
-    @pm.model
-    def nested_model(cond):
-        norm = yield dist.Normal("n", cond, 1)
+        norm = yield dist.HalfNormal("n", cond ** 2, transform=dist.transforms.Log())
         return norm
 
     @pm.model(keep_return=False)
@@ -48,79 +18,307 @@ def test_complex_model_no_keep_return():
         result = yield nested_model(norm, name="a")
         return result
 
+    return complex_model
+
+
+@pytest.fixture("module")
+def complex_model_with_observed():
+    @pm.model
+    def nested_model(cond):
+        norm = yield dist.HalfNormal(
+            "n", cond ** 2, observed=np.ones(10), transform=dist.transforms.Log()
+        )
+        return norm
+
+    @pm.model(keep_return=False)
+    def complex_model():
+        norm = yield dist.Normal("n", 0, 1)
+        result = yield nested_model(norm, name="a")
+        return result
+
+    return complex_model
+
+
+@pytest.fixture("module")
+def simple_model():
+    def simple_model():
+        norm = yield dist.Normal("n", 0, 1)
+        return norm
+
+    return simple_model
+
+
+@pytest.fixture("module")
+def transformed_model():
+    def transformed_model():
+        norm = yield dist.HalfNormal("n", 1, transform=dist.transforms.Log())
+        return norm
+
+    return transformed_model
+
+
+@pytest.fixture("module")
+def transformed_model_with_observed():
+    def transformed_model_with_observed():
+        norm = yield dist.HalfNormal("n", 1, transform=dist.transforms.Log(), observed=1.0)
+        return norm
+
+    return transformed_model_with_observed
+
+
+def test_simple_model(simple_model):
+    _, state = pm.evaluate_model(simple_model())
+    assert "n" in state.untransformed_values
+    assert not state.observed_values
+    assert not state.transformed_values
+
+
+def test_complex_model_keep_return():
+    @pm.model
+    def nested_model(cond):
+        norm = yield dist.HalfNormal("n", cond ** 2, transform=dist.transforms.Log())
+        return norm
+
+    @pm.model()
+    def complex_model():
+        norm = yield dist.Normal("n", 0, 1)
+        result = yield nested_model(norm, name="a")
+        return result
+
     _, state = pm.evaluate_model(complex_model())
 
-    assert set(state.values) == {"complex_model/n", "complex_model/a", "complex_model/a/n"}
+    assert set(state.untransformed_values) == {
+        "complex_model/n",
+        "complex_model/a",
+        "complex_model/a/n",
+        "complex_model",
+    }
+    assert not state.transformed_values  # we call untransformed executor
+    assert not state.observed_values
 
 
-def test_transformed_model_untransformed_executor():
-    def transformed_model():
-        norm = yield dist.HalfNormal("n", 1, transform=dist.transforms.Log())
-        return norm
+def test_complex_model_no_keep_return(complex_model):
+    _, state = pm.evaluate_model(complex_model())
 
+    assert set(state.untransformed_values) == {
+        "complex_model/n",
+        "complex_model/a",
+        "complex_model/a/n",
+    }
+    assert not state.transformed_values  # we call untransformed executor
+    assert not state.observed_values
+
+
+def test_transformed_model_untransformed_executor(transformed_model):
     _, state = pm.evaluate_model(transformed_model())
 
-    assert set(state.values) == {"n"}
+    assert set(state.untransformed_values) == {"n"}
+    assert not state.transformed_values  # we call untransformed executor
+    assert not state.observed_values
 
 
-def test_transformed_model_transformed_executor():
-    def transformed_model():
-        norm = yield dist.HalfNormal("n", 1, transform=dist.transforms.Log())
-        return norm
-
+def test_transformed_model_transformed_executor(transformed_model):
     _, state = pm.evaluate_model_transformed(transformed_model())
 
-    assert set(state.values) == {"n", "__log_n"}
-    assert np.allclose(state.values["n"], math.exp(state.values["__log_n"]))
+    assert set(state.all_values) == {"n", "__log_n"}
+    assert set(state.transformed_values) == {"__log_n"}
+    assert set(state.untransformed_values) == {"n"}
+    assert not state.observed_values
+    assert np.allclose(
+        state.untransformed_values["n"], math.exp(state.transformed_values["__log_n"])
+    )
 
 
-def test_transformed_model_transformed_executor_with_passed_value():
-    def transformed_model():
-        norm = yield dist.HalfNormal("n", 1, transform=dist.transforms.Log())
-        return norm
+def test_transformed_model_transformed_executor_with_passed_value(transformed_model):
+    _, state = pm.evaluate_model_transformed(transformed_model(), values=dict(n=1.0))
 
-    _, state = pm.evaluate_model_transformed(transformed_model(), n=1.0)
+    assert set(state.all_values) == {"n", "__log_n"}
+    assert set(state.transformed_values) == {"__log_n"}
+    assert set(state.untransformed_values) == {"n"}
+    np.testing.assert_allclose(state.all_values["__log_n"], 0.0)
 
-    assert set(state.values) == {"n", "__log_n"}
-    np.testing.assert_allclose(state.values["__log_n"], 0.0)
+    _, state = pm.evaluate_model_transformed(transformed_model(), values=dict(__log_n=0.0))
 
-    _, state = pm.evaluate_model_transformed(transformed_model(), __log_n=0.0)
-
-    assert set(state.values) == {"n", "__log_n"}
-    np.testing.assert_allclose(state.values["n"], 1.0)
+    assert set(state.all_values) == {"n", "__log_n"}
+    assert set(state.transformed_values) == {"__log_n"}
+    assert set(state.untransformed_values) == {"n"}
+    np.testing.assert_allclose(state.all_values["n"], 1.0)
 
 
 @pytest.mark.importorskip("tensorflow_probability")
-def test_transformed_executor_logp_tensorflow():
+def test_transformed_executor_logp_tensorflow(transformed_model):
     from tensorflow_probability import bijectors as bij, distributions as tfd
 
     norm_log = tfd.TransformedDistribution(tfd.HalfNormal(1), bij.Invert(bij.Exp()))
 
-    def transformed_model():
-        norm = yield dist.HalfNormal("n", 1, transform=dist.transforms.Log())
-        return norm
-
-    _, state = pm.evaluate_model_transformed(transformed_model(), __log_n=-math.pi)
+    _, state = pm.evaluate_model_transformed(transformed_model(), values=dict(__log_n=-math.pi))
     np.testing.assert_allclose(
         state.collect_log_prob(), norm_log.log_prob(-math.pi), equal_nan=False
     )
 
-    _, state = pm.evaluate_model_transformed(transformed_model(), n=math.exp(-math.pi))
+    _, state = pm.evaluate_model_transformed(transformed_model(), values=dict(n=math.exp(-math.pi)))
     np.testing.assert_allclose(
         state.collect_log_prob(), norm_log.log_prob(-math.pi), equal_nan=False
     )
 
 
 @pytest.mark.importorskip("tensorflow_probability")
-def test_executor_logp_tensorflow():
+def test_executor_logp_tensorflow(transformed_model):
     from tensorflow_probability import distributions as tfd
 
     norm = tfd.HalfNormal(1)
 
-    def transformed_model():
-        norm = yield dist.HalfNormal("n", 1, transform=dist.transforms.Log())
-        return norm
-
-    _, state = pm.evaluate_model(transformed_model(), n=math.pi)
+    _, state = pm.evaluate_model(transformed_model(), values=dict(n=math.pi))
 
     np.testing.assert_allclose(state.collect_log_prob(), norm.log_prob(math.pi), equal_nan=False)
+
+
+def test_unnamed_distribution():
+    f = lambda: (yield pm.distributions.Normal.dist(0, 1))
+    with pytest.raises(pm.flow.executor.EvaluationError) as e:
+        pm.evaluate_model(f())
+    assert e.match("anonymous Distribution")
+
+
+def test_single_distribution():
+    _, state = pm.evaluate_model(pm.distributions.Normal("n", 0, 1))
+    assert "n" in state.all_values
+
+
+def test_raise_if_return_distribution():
+    def invalid_model():
+        yield pm.distributions.Normal("n1", 0, 1)
+        return pm.distributions.Normal("n2", 0, 1)
+
+    with pytest.raises(pm.flow.executor.EvaluationError) as e:
+        pm.evaluate_model(invalid_model())
+    assert e.match("should not contain")
+
+
+def test_observed_are_passed_correctly(complex_model_with_observed):
+    _, state = pm.evaluate_model(complex_model_with_observed())
+
+    assert set(state.untransformed_values) == {"complex_model/n", "complex_model/a"}
+    assert not state.transformed_values  # we call untransformed executor
+    assert set(state.observed_values) == {"complex_model/a/n"}
+    assert np.allclose(state.all_values["complex_model/a/n"], np.ones(10))
+
+
+def test_observed_are_set_to_none_for_posterior_predictive_correctly(complex_model_with_observed):
+    _, state = pm.evaluate_model(
+        complex_model_with_observed(), observed={"complex_model/a/n": None}
+    )
+
+    assert set(state.untransformed_values) == {
+        "complex_model/n",
+        "complex_model/a",
+        "complex_model/a/n",
+    }
+    assert not state.transformed_values  # we call untransformed executor
+    assert not state.observed_values
+    assert not np.allclose(state.all_values["complex_model/a/n"], np.ones(10))
+
+
+def test_observed_do_not_produce_transformed_values(transformed_model_with_observed):
+    _, state = pm.evaluate_model_transformed(transformed_model_with_observed())
+    assert set(state.observed_values) == {"n"}
+    assert not state.transformed_values
+    assert not state.untransformed_values
+
+
+def test_observed_do_not_produce_transformed_values_case_programmatic(transformed_model):
+    _, state = pm.evaluate_model_transformed(transformed_model(), observed=dict(n=1.0))
+    assert set(state.observed_values) == {"n"}
+    assert not state.transformed_values
+    assert not state.untransformed_values
+
+
+def test_observed_do_not_produce_transformed_values_case_override(transformed_model_with_observed):
+    _, state = pm.evaluate_model_transformed(
+        transformed_model_with_observed(), observed=dict(n=None)
+    )
+    assert not state.observed_values
+    assert set(state.transformed_values) == {"__log_n"}
+    assert set(state.untransformed_values) == {"n"}
+
+
+def test_observed_do_not_produce_transformed_values_case_override_with_set_value(
+    transformed_model_with_observed
+):
+    _, state = pm.evaluate_model_transformed(
+        transformed_model_with_observed(), values=dict(n=1.0), observed=dict(n=None)
+    )
+    assert not state.observed_values
+    assert set(state.transformed_values) == {"__log_n"}
+    assert set(state.untransformed_values) == {"n"}
+    np.testing.assert_allclose(state.all_values["__log_n"], 0.0)
+
+    _, state = pm.evaluate_model_transformed(
+        transformed_model_with_observed(), values=dict(__log_n=0.0), observed=dict(n=None)
+    )
+    assert not state.observed_values
+    assert set(state.transformed_values) == {"__log_n"}
+    assert set(state.untransformed_values) == {"n"}
+    np.testing.assert_allclose(state.all_values["n"], 1.0)
+
+
+def test_observed_cant_mix_with_untransformed_and_raises_an_error_case_transformed_executor(
+    transformed_model_with_observed
+):
+    with pytest.raises(pm.flow.executor.EvaluationError) as e:
+        _, state = pm.evaluate_model_transformed(
+            transformed_model_with_observed(), values=dict(n=0.0)
+        )
+    assert e.match("{'n': None}")
+    assert e.match("'n' from untransformed values")
+
+
+def test_observed_cant_mix_with_untransformed_and_raises_an_error_case_untransformed_executor(
+    transformed_model_with_observed
+):
+    with pytest.raises(pm.flow.executor.EvaluationError) as e:
+        _, state = pm.evaluate_model(transformed_model_with_observed(), values=dict(n=0.0))
+    assert e.match("{'n': None}")
+    assert e.match("'n' from untransformed values")
+
+
+def test_observed_cant_mix_with_transformed_and_raises_an_error(transformed_model_with_observed):
+    with pytest.raises(pm.flow.executor.EvaluationError) as e:
+        _, state = pm.evaluate_model_transformed(
+            transformed_model_with_observed(), values=dict(__log_n=0.0)
+        )
+    assert e.match("{'n': None}")
+    assert e.match("'__log_n' from transformed values")
+
+
+def test_as_sampling_state_works_observed_is_constrained(complex_model_with_observed):
+    _, state = pm.evaluate_model(complex_model_with_observed())
+    sampling_state = state.as_sampling_state()
+    assert not sampling_state.transformed_values
+    assert set(sampling_state.observed_values) == {"complex_model/a/n"}
+    assert set(sampling_state.untransformed_values) == {"complex_model/n"}
+
+
+def test_as_sampling_state_works_observed_is_set_to_none(complex_model_with_observed):
+    _, state = pm.evaluate_model_transformed(
+        complex_model_with_observed(), observed={"complex_model/a/n": None}
+    )
+    sampling_state = state.as_sampling_state()
+    assert set(sampling_state.transformed_values) == {"complex_model/a/__log_n"}
+    assert not sampling_state.observed_values
+    assert set(sampling_state.untransformed_values) == {"complex_model/n"}
+
+
+def test_as_sampling_state_works_if_transformed_exec(complex_model_with_observed):
+    _, state = pm.evaluate_model_transformed(complex_model_with_observed())
+    sampling_state = state.as_sampling_state()
+    assert not sampling_state.transformed_values
+    assert set(sampling_state.observed_values) == {"complex_model/a/n"}
+    assert set(sampling_state.untransformed_values) == {"complex_model/n"}
+
+
+def test_as_sampling_state_does_not_works_if_untransformed_exec(complex_model):
+    _, state = pm.evaluate_model(complex_model())
+    with pytest.raises(TypeError) as e:
+        state.as_sampling_state()
+    e.match("'complex_model/a/__log_n' is not found")

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -90,8 +90,8 @@ def test_transformed_model_transformed_executor_with_passed_value():
     np.testing.assert_allclose(state.values["n"], 1.0)
 
 
+@pytest.mark.importorskip("tensorflow_probability")
 def test_transformed_executor_logp_tensorflow():
-    pytest.importorskip("tensorflow_probability")
     from tensorflow_probability import bijectors as bij, distributions as tfd
 
     norm_log = tfd.TransformedDistribution(tfd.HalfNormal(1), bij.Invert(bij.Exp()))
@@ -111,8 +111,8 @@ def test_transformed_executor_logp_tensorflow():
     )
 
 
+@pytest.mark.importorskip("tensorflow_probability")
 def test_executor_logp_tensorflow():
-    pytest.importorskip("tensorflow_probability")
     from tensorflow_probability import distributions as tfd
 
     norm = tfd.HalfNormal(1)

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -403,3 +403,13 @@ def test_uncatched_exception_works():
     with pytest.raises(pm.flow.executor.StopExecution) as e:
         pm.evaluate_model_transformed(a_model())
     assert e.match("something_bad")
+
+
+def test_none_yield():
+    def model():
+        yield None
+        yield dist.Normal("n", 0, 1)
+
+    with pytest.raises(pm.flow.executor.EvaluationError) as e:
+        pm.evaluate_model_transformed(model())
+    assert e.match("processed in evaluation")


### PR DESCRIPTION
Important design changes

* `SamplingState` class has been changed to distinguish observed from regular variables
* added `Dist(..., observed=value)` API
* added a protocol for suppressing values provided in `Dist(..., observed=value)` mapping the name to None in observed dict. (Un)transformed values are only can be set instead of observed if the observed is suppressed.
* added `Dist.dist(...)` api that allows creating distributions that yet do not have a name. To use the created distribution one should call `dist.prior(name)` on it.