### PR TITLE
Add deterministic variable

### DIFF
--- a/pymc4/distributions/abstract/distribution.py
+++ b/pymc4/distributions/abstract/distribution.py
@@ -203,3 +203,22 @@ class Potential(object):
     @abc.abstractmethod
     def value_numpy(self):
         raise NotImplementedError
+
+
+class Deterministic(Model):
+    """An object that can be sampled, but has no log probability."""
+
+    def __init__(self, name: Optional[NameType], value):
+        super().__init__(
+            self.unpack_distribution, name=name, keep_return=True, keep_auxiliary=False
+        )
+        self._init_backend()
+        self.value = value
+
+    def unpack_distribution(self):
+        return unpack(self.value)
+
+    @abc.abstractmethod
+    def _init_backend(self):
+        """Initialize the backend."""
+        pass

--- a/pymc4/distributions/tensorflow/__init__.py
+++ b/pymc4/distributions/tensorflow/__init__.py
@@ -1,3 +1,3 @@
 from pymc4.distributions.tensorflow.continuous import *
-from pymc4.distributions.tensorflow.distribution import Potential
+from pymc4.distributions.tensorflow.distribution import Potential, Deterministic
 from pymc4.distributions.tensorflow import transforms

--- a/pymc4/distributions/tensorflow/distribution.py
+++ b/pymc4/distributions/tensorflow/distribution.py
@@ -1,4 +1,8 @@
-from pymc4.distributions.abstract.distribution import Distribution, Potential as BasePotential
+from pymc4.distributions.abstract.distribution import (
+    Distribution,
+    Potential as BasePotential,
+    Deterministic as BaseDeterministic,
+)
 from tensorflow_probability import distributions as tfd
 
 
@@ -32,3 +36,7 @@ class Potential(BasePotential):
     @property
     def value_numpy(self):
         return self.value.numpy()
+
+
+class Deterministic(BaseDeterministic):
+    """Backend distribution for Tensorflow distributions."""


### PR DESCRIPTION
I also removed the `tf_seed` fixture, since it is autoused.

The test suite shows how deterministics work right now:

```python
@pm.model
def half_normal(mu, sigma):
    normal = yield pm.Normal(name='normal', mu=mu, sigma=sigma, plate=3)
    yield pm.Deterministic(name="abs_normal", value=tf.math.abs(normal))

_, state = pm.evaluate_model(half_normal(0, 1))
print(state.untransformed_values['half_normal/normal'].numpy(),
      state.untransformed_values['half_normal/abs_normal'].numpy())
```
gives something like
```python
(array([-0.02932515, -1.9230154 ,  0.9288907 ], dtype=float32),
 array([0.02932515, 1.9230154 , 0.9288907 ], dtype=float32))
```

I'll wait on merging this, since I am not sure if I missed something in the design.
