### PR TITLE
Use codecov for code coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,20 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project: yes
+    patch: yes
+    changes: no
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes
+  require_base: no        # [yes :: must have a base report to post]
+  require_head: yes       # [yes :: must have a head report to post]
+  branches: null          # branch names that can post comment

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PyMC4 (Pre-release)
 
 [![Build Status](https://dev.azure.com/pymc-devs/pymc4/_apis/build/status/pymc-devs.pymc4?branchName=master)](https://dev.azure.com/pymc-devs/pymc4/_build/latest?definitionId=1&branchName=master)
-![Azure DevOps coverage](https://img.shields.io/azure-devops/coverage/pymc-devs/pymc4/1)
+[![Coverage Status](https://codecov.io/gh/pymc-devs/pymc4/branch/master/graph/badge.svg)](https://codecov.io/gh/pymc-devs/pymc4)
 
 Now with flowing tensors.

--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 [![Build Status](https://dev.azure.com/pymc-devs/pymc4/_apis/build/status/pymc-devs.pymc4?branchName=master)](https://dev.azure.com/pymc-devs/pymc4/_build/latest?definitionId=1&branchName=master)
 [![Coverage Status](https://codecov.io/gh/pymc-devs/pymc4/branch/master/graph/badge.svg)](https://codecov.io/gh/pymc-devs/pymc4)
 
-Now with flowing tensors.
+Now with flowing tensors. 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ strategy:
       python.version: "3.6"
     Python37:
       python.version: "3.7"
-    Python37:
+    Python38:
       python.version: "3.8"
 
 steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,8 @@ strategy:
       python.version: "3.6"
     Python37:
       python.version: "3.7"
+    Python37:
+      python.version: "3.8"
 
 steps:
   - task: UsePythonVersion@0
@@ -44,14 +46,7 @@ steps:
       python -m pytest -xv --cov pymc4 --junitxml=junit/test-results.xml --cov-report xml --cov-report term --cov-report html .
     displayName: "pytest"
 
-  - task: PublishTestResults@2
+  - script: |
+      bash <(curl -s https://codecov.io/bash)
+    displayName: "Publish test results to codecov for Python $(python.version)"
     condition: succeededOrFailed()
-    inputs:
-      testResultsFiles: "**/test-*.xml"
-      testRunTitle: "Publish test results for Python $(python.version)"
-
-  - task: PublishCodeCoverageResults@1
-    inputs:
-      codeCoverageTool: Cobertura
-      summaryFileLocation: "$(System.DefaultWorkingDirectory)/**/coverage.xml"
-      reportDirectory: "$(System.DefaultWorkingDirectory)/**/htmlcov"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,8 +9,6 @@ strategy:
       python.version: "3.6"
     Python37:
       python.version: "3.7"
-    Python38:
-      python.version: "3.8"
 
 steps:
   - task: UsePythonVersion@0

--- a/pymc4/hmc/quadpotential.py
+++ b/pymc4/hmc/quadpotential.py
@@ -54,7 +54,7 @@ def partial_check_positive_definite(C):
         d = C
     else:
         d = np.diag(C)
-    i, = np.nonzero(np.logical_or(np.isnan(d), d <= 0))
+    (i,) = np.nonzero(np.logical_or(np.isnan(d), d <= 0))
 
     if len(i):
         raise PositiveDefiniteError("Simple check failed. Diagonal contains negatives", i)

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -256,7 +256,7 @@ def test_observed_do_not_produce_transformed_values_case_override(transformed_mo
 
 
 def test_observed_do_not_produce_transformed_values_case_override_with_set_value(
-    transformed_model_with_observed
+    transformed_model_with_observed,
 ):
     _, state = pm.evaluate_model_transformed(
         transformed_model_with_observed(), values=dict(n=1.0), observed=dict(n=None)
@@ -276,7 +276,7 @@ def test_observed_do_not_produce_transformed_values_case_override_with_set_value
 
 
 def test_observed_cant_mix_with_untransformed_and_raises_an_error_case_transformed_executor(
-    transformed_model_with_observed
+    transformed_model_with_observed,
 ):
     with pytest.raises(pm.flow.executor.EvaluationError) as e:
         _, state = pm.evaluate_model_transformed(
@@ -287,7 +287,7 @@ def test_observed_cant_mix_with_untransformed_and_raises_an_error_case_transform
 
 
 def test_observed_cant_mix_with_untransformed_and_raises_an_error_case_untransformed_executor(
-    transformed_model_with_observed
+    transformed_model_with_observed,
 ):
     with pytest.raises(pm.flow.executor.EvaluationError) as e:
         _, state = pm.evaluate_model(transformed_model_with_observed(), values=dict(n=0.0))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,7 +22,7 @@ def mock_biwrap_functools_call(monkeypatch):
 
 
 def test_biwrap_and_mocked_functools_raises_exception_with_called_decorator(
-    mock_biwrap_functools_call
+    mock_biwrap_functools_call,
 ):
     """Test code path for called decorator by adding exception to to pm4.utils.functools.partial"""
 


### PR DESCRIPTION
Codecov was a nice replacement for coveralls in pymc3. This PR changes the currently used azure-pipelines coverage publisher and reporter tasks to codecov.io instead. We'll get the same nice coverage graphs for PRs and reports as in pymc3.

I also added a python3.8 test environment (as it's basically free because we haven't hit the limit of parallel jobs in azure).