### PR TITLE
Tighten requirements, tighten lint, update style

### DIFF
--- a/pymc4/distributions/continuous.py
+++ b/pymc4/distributions/continuous.py
@@ -1,7 +1,8 @@
 """PyMC4 continuous random variables for tensorflow."""
 import math
 
-import tensorflow_probability as tfp
+from tensorflow_probability import distributions as tfd
+from tensorflow_probability import bijectors as bij
 from pymc4.distributions.distribution import (
     ContinuousDistribution,
     PositiveContinuousDistribution,
@@ -9,8 +10,6 @@ from pymc4.distributions.distribution import (
     BoundedContinuousDistribution,
 )
 
-
-tfd = tfp.distributions
 
 __all__ = [
     "Beta",
@@ -784,7 +783,7 @@ class LogitNormal(UnitContinuousDistribution):
         loc, scale = conditions["loc"], conditions["scale"]
         return tfd.TransformedDistribution(
             distribution=tfd.Normal(loc=loc, scale=scale),
-            bijector=tfp.bijectors.Sigmoid(),
+            bijector=bij.Sigmoid(),
             name="LogitNormal",
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-arviz
-gast==0.2.2
-tf-nightly-2.0-preview
-tfp-nightly
+arviz>=0.4.1
+gast>=0.2.2
+tensorflow>=2.0
+tensorflow-probability>=0.8
 pymc3
-scipy
+scipy>=0.18.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 arviz>=0.4.1
-gast>=0.2.2
+gast==0.2.2
 tensorflow>=2.0
 tensorflow-probability>=0.8
 pymc3

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -10,12 +10,12 @@ echo "Skipping documentation check. Re-enabling this would be a helpful contribu
 echo "Success!"
 
 echo "Checking code style with black..."
-python -m black -l 100 --check "${SRC_DIR}"/pymc4/
+python -m black -l 100 --check "${SRC_DIR}"/pymc4/ "${SRC_DIR}"/tests/
 echo "Success!"
 
 echo "Type checking with mypy..."
 python -m mypy --ignore-missing-imports "${SRC_DIR}"/pymc4/
 
 echo "Checking code style with pylint..."
-python -m pylint "${SRC_DIR}"/pymc4/
+python -m pylint "${SRC_DIR}"/pymc4/ "${SRC_DIR}"/tests/
 echo "Success!"

--- a/tests/test_forward_sampling.py
+++ b/tests/test_forward_sampling.py
@@ -1,6 +1,5 @@
 import pytest
 import re
-import itertools
 import collections
 import numpy as np
 import tensorflow as tf
@@ -74,19 +73,11 @@ def model_with_observed_fixture(request):
 def posterior_predictive_fixture(model_with_observed_fixture):
     num_samples = 40
     num_chains = 3
-    (model, observed, core_ppc_shapes, observed_in_RV,) = model_with_observed_fixture
+    (model, observed, core_ppc_shapes, observed_in_RV) = model_with_observed_fixture
     trace, _ = pm.inference.sampling.sample(
-        model(), num_samples=num_samples, num_chains=num_chains, observed=observed,
+        model(), num_samples=num_samples, num_chains=num_chains, observed=observed
     )
-    return (
-        model,
-        observed,
-        core_ppc_shapes,
-        observed_in_RV,
-        trace,
-        num_samples,
-        num_chains,
-    )
+    return (model, observed, core_ppc_shapes, observed_in_RV, trace, num_samples, num_chains)
 
 
 def test_sample_prior_predictive(model_fixture, sample_shape_fixture, sample_from_observed_fixture):
@@ -122,12 +113,12 @@ def test_sample_prior_predictive_var_names(model_fixture):
     model, observed = model_fixture
 
     prior = forward_sampling.sample_prior_predictive(
-        model(), var_names=["model/sd"], sample_shape=(),
+        model(), var_names=["model/sd"], sample_shape=()
     )
     assert set(prior) == set(["model/sd"])
 
     prior = forward_sampling.sample_prior_predictive(
-        model(), var_names=["model/x", "model/y"], sample_shape=(),
+        model(), var_names=["model/x", "model/y"], sample_shape=()
     )
     assert set(prior) == set(["model/x", "model/y"])
 
@@ -146,7 +137,7 @@ def test_sample_prior_predictive_var_names(model_fixture):
     )
     with pytest.raises(ValueError, match=re.escape(expected_message)):
         prior = forward_sampling.sample_prior_predictive(
-            model_func, var_names=["X", "model/y"], sample_shape=(),
+            model_func, var_names=["X", "model/y"], sample_shape=()
         )
 
 
@@ -180,7 +171,7 @@ def test_posterior_predictive_executor(model_with_observed_fixture):
             == shape
         )
         if var in observed:
-            assert np.any(ppc_state.all_values[var] != val)
+            assert np.any(ppc_state.all_values[var] != val for val in observed.values())
 
 
 def test_sample_posterior_predictive(posterior_predictive_fixture):
@@ -238,10 +229,7 @@ def test_sample_ppc_corrupt_trace():
 
     trace1 = {"model/x": np.ones(7, dtype="float32")}
 
-    trace2 = {
-        "model/x": np.ones(5, dtype="float32"),
-        "model/y": np.array(0, dtype="float32"),
-    }
+    trace2 = {"model/x": np.ones(5, dtype="float32"), "model/y": np.array(0, dtype="float32")}
     with pytest.raises(EvaluationError):
         pm.sample_posterior_predictive(model(), trace1)
     with pytest.raises(EvaluationError):

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -3,7 +3,6 @@ import itertools
 import pymc4 as pm
 import numpy as np
 from scipy import stats
-from pymc4 import distributions as dist
 import tensorflow as tf
 
 
@@ -172,4 +171,4 @@ def test_sampling_with_deterministics_in_nested_models(
         model=model(), num_samples=10, num_chains=4, burn_in=100, step_size=0.1, xla=xla_fixture
     )
     for deterministic, (inputs, op) in deterministic_mapping.items():
-        np.testing.assert_allclose(trace[deterministic], op(*[trace[i] for i in inputs]))
+        np.testing.assert_allclose(trace[deterministic], op(*[trace[i] for i in inputs]), rtol=1e-6)


### PR DESCRIPTION
General tidying up:

- Consistent `import tensorflow_probability.distributions as tfd` (and for bijectors): I think the tfp team does not do this, but it feels like a better practice.
- Added minimum requirements in the requirements.txt. I think we will need to do this before a beta release. I also assume we will drop pymc3 as a requirement, so I did not add a minimum version there.
- Linting now runs `black` and `pylint` on the test directories. It passes, so seems good to do.
- Fixed a bunch of small warnings getting emitted.