### PR TITLE
Untransform variables in inference

### DIFF
--- a/pymc4/flow/executor.py
+++ b/pymc4/flow/executor.py
@@ -224,7 +224,7 @@ class SamplingState:
             posterior_predictives=self.posterior_predictives,
         )
 
-    def as_sampling_state(self) -> "SamplingState":
+    def as_sampling_state(self) -> "Tuple[SamplingState, List[str]]":
         """Create a sampling state that should be used within MCMC sampling.
 
         There are some principles that hold for the state.
@@ -241,7 +241,9 @@ class SamplingState:
             )
         untransformed_values = dict()
         transformed_values = dict()
+        need_to_transform_after = list()
         observed_values = dict()
+
         for name, dist in self.distributions.items():
             namespec = utils.NameParts.from_name(name)
             if dist.transform is not None and name not in self.observed_values:
@@ -258,6 +260,7 @@ class SamplingState:
                     transformed_values[
                         transformed_namespec.full_original_name
                     ] = self.transformed_values[transformed_namespec.full_original_name]
+                    need_to_transform_after.append(transformed_namespec.full_untransformed_name)
             else:
                 if name in self.observed_values:
                     observed_values[name] = self.observed_values[name]
@@ -269,10 +272,13 @@ class SamplingState:
                         "in the state. This may happen if the current "
                         "state was modified in the wrong way."
                     )
-        return self.__class__(
-            transformed_values=transformed_values,
-            untransformed_values=untransformed_values,
-            observed_values=observed_values,
+        return (
+            self.__class__(
+                transformed_values=transformed_values,
+                untransformed_values=untransformed_values,
+                observed_values=observed_values,
+            ),
+            need_to_transform_after,
         )
 
 

--- a/pymc4/flow/posterior_predictive_executor.py
+++ b/pymc4/flow/posterior_predictive_executor.py
@@ -48,32 +48,31 @@ class PosteriorPredictiveSamplingExecutor(TransformedSamplingExecutor):
         Distribution instance with no observations.
         4) This distribution will be yielded instead of the original incoming
         dist, and it will be used for posterior predictive sampling
-
+    
         Parameters
         ----------
         dist: Union[types.GeneratorType, pymc4.coroutine_model.Model]
-            The
+            The 
         model_info: Mapping[str, Any]
-            Either ``dist.model_info`` or
+            Either ``dist.model_info`` or 
             ``pymc4.coroutine_model.Model.default_model_info`` if ``dist`` is not a
             ``pymc4.courutine_model.Model`` instance.
         state: SamplingState
             The model's evaluation state.
-
+    
         Returns
         -------
         model: Union[types.GeneratorType, pymc4.coroutine_model.Model]
             The original ``dist`` if it was not an observed ``Distribution`` or
             the ``Distribution`` with the changed ``batch_shape`` and observations
             set to ``None``.
-
+    
         Raises
         ------
         EvaluationError
             When ``dist`` and its passed observed value don't have a consistent
             shape
         """
-        transformed = state.transformed_values
         dist = super().modify_distribution(dist, model_info, state)
         # We only modify the shape of Distribution instances that have observed
         # values

--- a/pymc4/flow/posterior_predictive_executor.py
+++ b/pymc4/flow/posterior_predictive_executor.py
@@ -9,16 +9,18 @@ import tensorflow as tf
 from pymc4 import scopes
 from pymc4.distributions.distribution import Distribution
 from pymc4.flow.executor import (
+    EvaluationError,
     ModelType,
+    SamplingExecutor,
     SamplingState,
     observed_value_in_evaluation,
     get_observed_tensor_shape,
     assert_values_compatible_with_distribution,
 )
-from pymc4.flow.transformed_executor import TransformedSamplingExecutor
+from pymc4.flow.transformed_executor import transform_dist_if_necessary
 
 
-class PosteriorPredictiveSamplingExecutor(TransformedSamplingExecutor):
+class PosteriorPredictiveSamplingExecutor(SamplingExecutor):
     """Execute the probabilistic model for posterior predictive sampling.
 
     This means that the model will be evaluated in the same way as the
@@ -34,6 +36,10 @@ class PosteriorPredictiveSamplingExecutor(TransformedSamplingExecutor):
     used for posterior predictive sampling
     """
 
+    def validate_state(self, state: SamplingState):
+        """Validate that the model is not in a bad state."""
+        return
+
     def modify_distribution(
         self, dist: ModelType, model_info: Mapping[str, Any], state: SamplingState
     ) -> ModelType:
@@ -48,25 +54,25 @@ class PosteriorPredictiveSamplingExecutor(TransformedSamplingExecutor):
         Distribution instance with no observations.
         4) This distribution will be yielded instead of the original incoming
         dist, and it will be used for posterior predictive sampling
-    
+
         Parameters
         ----------
         dist: Union[types.GeneratorType, pymc4.coroutine_model.Model]
-            The 
+            The
         model_info: Mapping[str, Any]
-            Either ``dist.model_info`` or 
+            Either ``dist.model_info`` or
             ``pymc4.coroutine_model.Model.default_model_info`` if ``dist`` is not a
             ``pymc4.courutine_model.Model`` instance.
         state: SamplingState
             The model's evaluation state.
-    
+
         Returns
         -------
         model: Union[types.GeneratorType, pymc4.coroutine_model.Model]
             The original ``dist`` if it was not an observed ``Distribution`` or
             the ``Distribution`` with the changed ``batch_shape`` and observations
             set to ``None``.
-    
+
         Raises
         ------
         EvaluationError
@@ -76,9 +82,12 @@ class PosteriorPredictiveSamplingExecutor(TransformedSamplingExecutor):
         dist = super().modify_distribution(dist, model_info, state)
         # We only modify the shape of Distribution instances that have observed
         # values
+        dist = transform_dist_if_necessary(dist, state, allow_transformed_and_untransformed=False)
         if not isinstance(dist, Distribution):
             return dist
         scoped_name = scopes.variable_name(dist.name)
+        if scoped_name is None:
+            raise EvaluationError("Attempting to create an anonymous Distribution")
 
         observed_value = observed_value_in_evaluation(scoped_name, dist, state)
         if observed_value is None:

--- a/pymc4/flow/posterior_predictive_executor.py
+++ b/pymc4/flow/posterior_predictive_executor.py
@@ -48,31 +48,32 @@ class PosteriorPredictiveSamplingExecutor(TransformedSamplingExecutor):
         Distribution instance with no observations.
         4) This distribution will be yielded instead of the original incoming
         dist, and it will be used for posterior predictive sampling
-    
+
         Parameters
         ----------
         dist: Union[types.GeneratorType, pymc4.coroutine_model.Model]
-            The 
+            The
         model_info: Mapping[str, Any]
-            Either ``dist.model_info`` or 
+            Either ``dist.model_info`` or
             ``pymc4.coroutine_model.Model.default_model_info`` if ``dist`` is not a
             ``pymc4.courutine_model.Model`` instance.
         state: SamplingState
             The model's evaluation state.
-    
+
         Returns
         -------
         model: Union[types.GeneratorType, pymc4.coroutine_model.Model]
             The original ``dist`` if it was not an observed ``Distribution`` or
             the ``Distribution`` with the changed ``batch_shape`` and observations
             set to ``None``.
-    
+
         Raises
         ------
         EvaluationError
             When ``dist`` and its passed observed value don't have a consistent
             shape
         """
+        transformed = state.transformed_values
         dist = super().modify_distribution(dist, model_info, state)
         # We only modify the shape of Distribution instances that have observed
         # values

--- a/pymc4/flow/transformed_executor.py
+++ b/pymc4/flow/transformed_executor.py
@@ -4,10 +4,19 @@ Specifically, we wish to transform distributions whose support is bounded on
 one or both sides to distributions that are supported for all real numbers.
 """
 import functools
+
+
+from typing import Mapping, Any
 from pymc4 import scopes, distributions
 from pymc4.distributions import distribution
 from pymc4.distributions.transforms import JacobianPreference
-from pymc4.flow.executor import SamplingExecutor, EvaluationError, observed_value_in_evaluation
+from pymc4.flow.executor import (
+    SamplingExecutor,
+    EvaluationError,
+    observed_value_in_evaluation,
+    ModelType,
+    SamplingState,
+)
 
 
 class TransformedSamplingExecutor(SamplingExecutor):
@@ -17,124 +26,116 @@ class TransformedSamplingExecutor(SamplingExecutor):
         """Validate that the model is not in a bad state."""
         return
 
-    def modify_distribution(self, dist, model_info, state):
+    def modify_distribution(
+        self, dist: ModelType, model_info: Mapping[str, Any], state: SamplingState
+    ) -> ModelType:
         """Apply transformations to a distribution."""
         dist = super().modify_distribution(dist, model_info, state)
         if not isinstance(dist, distribution.Distribution):
             return dist
-        scoped_name = scopes.variable_name(dist.name)
 
-        if dist.transform is None or dist.model_info.get(  # do nothing else if no transform is set
-            "autotransformed", False
-        ):  # already autotransformed, do nothing else
-            return dist
-        transform = dist.transform
-        transformed_scoped_name = scopes.variable_name(
-            # double underscore stands for transform
-            "__{}_{}".format(transform.name, dist.name)
+        return transform_dist_if_necessary(dist, state, allow_transformed_and_untransformed=True)
+
+
+def make_untransformed_model(dist, transform, state):
+    # we gonna sample here, but logp should be computed for the transformed space
+    # 0. as explained above we indicate we already performed autotransform
+    dist.model_info["autotransformed"] = True
+    # 1. sample a value, as we've checked there is no state provided
+    # we need `dist.model_info["autotransformed"] = True` here not to get in a trouble
+    # the return value is not yet user facing
+    sampled_untransformed_value = yield dist
+    sampled_transformed_value = transform.forward(sampled_untransformed_value)
+    # already stored untransformed value via yield
+    # state.values[scoped_name] = sampled_untransformed_value
+    transformed_scoped_name = scopes.transformed_variable_name(transform.name, dist.name)
+    state.transformed_values[transformed_scoped_name] = sampled_transformed_value
+    # 2. increment the potential
+    if transform.jacobian_preference == JacobianPreference.Forward:
+        potential_fn = functools.partial(
+            transform.forward_log_det_jacobian, sampled_untransformed_value
         )
-        if observed_value_in_evaluation(scoped_name, dist, state) is not None:
-            # do not modify a distribution if it is observed
-            # same for programmatically observed
-            # but not for programmatically set to unobserved (when value is None)
-            # but raise if we have transformed value passed in dict
-            if transformed_scoped_name in state.transformed_values:
-                raise EvaluationError(
-                    EvaluationError.OBSERVED_VARIABLE_IS_NOT_SUPPRESSED_BUT_ADDITIONAL_TRANSFORMED_VALUE_PASSED.format(
-                        scoped_name, transformed_scoped_name
-                    )
-                )
-            if scoped_name in state.untransformed_values:
-                raise EvaluationError(
-                    EvaluationError.OBSERVED_VARIABLE_IS_NOT_SUPPRESSED_BUT_ADDITIONAL_VALUE_PASSED.format(
-                        scoped_name, scoped_name
-                    )
-                )
-            return dist
+        coef = -1.0
+    else:
+        potential_fn = functools.partial(
+            transform.inverse_log_det_jacobian, sampled_transformed_value
+        )
+        coef = 1.0
+    yield distributions.Potential(potential_fn, coef=coef)
+    # 3. return value to the user
+    return sampled_untransformed_value
 
+
+def make_transformed_model(dist, transform, state):
+    # 1. now compute all the variables: in the transformed and untransformed space
+    scoped_name = scopes.variable_name(dist.name)
+    transformed_scoped_name = scopes.transformed_variable_name(transform.name, dist.name)
+    state.untransformed_values[scoped_name] = transform.inverse(
+        state.transformed_values[transformed_scoped_name]
+    )
+    # disable sampling and save cached results to store for yield dist
+
+    # once we are done with variables we can yield the value in untransformed space
+    # to the user and also increment the potential
+
+    # Important:
+    # I have no idea yet, how to make that beautiful.
+    # Here we indicate the distribution is already autotransformed nto to get in the infinite loop
+    dist.model_info["autotransformed"] = True
+
+    # 2. here decide on logdet computation, this might be effective
+    # with transformed value, but not with an untransformed one
+    # this information is stored in transform.jacobian_preference class attribute
+    # we postpone the computation of logdet as it might have some overhead
+    if transform.jacobian_preference == JacobianPreference.Forward:
+        potential_fn = functools.partial(
+            transform.forward_log_det_jacobian, state.untransformed_values[scoped_name]
+        )
+        coef = -1.0
+    else:
+        potential_fn = functools.partial(
+            transform.inverse_log_det_jacobian, state.transformed_values[transformed_scoped_name]
+        )
+        coef = 1.0
+    yield distributions.Potential(potential_fn, coef=coef)
+    # 3. final return+yield will return untransformed_value
+    # as it is stored in state.values
+    # Note: we need yield here to make another checks on name duplicates, etc
+    return (yield dist)
+
+
+def transform_dist_if_necessary(dist, state, *, allow_transformed_and_untransformed):
+    if dist.transform is None or dist.model_info.get("autotransformed", False):
+        return dist
+    scoped_name = scopes.variable_name(dist.name)
+    transform = dist.transform
+    transformed_scoped_name = scopes.transformed_variable_name(transform.name, dist.name)
+    if observed_value_in_evaluation(scoped_name, dist, state) is not None:
+        # do not modify a distribution if it is observed
+        # same for programmatically observed
+        # but not for programmatically set to unobserved (when value is None)
+        # but raise if we have transformed value passed in dict
         if transformed_scoped_name in state.transformed_values:
-            # We do not sample in this if branch
+            raise EvaluationError(
+                EvaluationError.OBSERVED_VARIABLE_IS_NOT_SUPPRESSED_BUT_ADDITIONAL_TRANSFORMED_VALUE_PASSED.format(
+                    scoped_name, transformed_scoped_name
+                )
+            )
+        if scoped_name in state.untransformed_values:
+            raise EvaluationError(
+                EvaluationError.OBSERVED_VARIABLE_IS_NOT_SUPPRESSED_BUT_ADDITIONAL_VALUE_PASSED.format(
+                    scoped_name, scoped_name
+                )
+            )
+        return dist
 
-            # # 0. do not allow ambiguity in state, make sure only one value is provided to compute logp
-            # if (
-            #     transformed_scoped_name in state.transformed_values
-            #     and scoped_name in state.untransformed_values
-            # ):
-            #     raise EvaluationError(
-            #         "Found both transformed and untransformed variables in the state: "
-            #         "'{} and '{}', but need exactly one".format(
-            #             scoped_name, transformed_scoped_name
-            #         )
-            #     )
-
-            def model():
-                # 1. now compute all the variables: in the transformed and untransformed space
-                if transformed_scoped_name in state.transformed_values:
-                    transformed_value = state.transformed_values[transformed_scoped_name]
-                    untransformed_value = transform.inverse(transformed_value)
-                else:
-                    untransformed_value = state.untransformed_values[scoped_name]
-                    transformed_value = transform.forward(untransformed_value)
-                # these lines below
-                state.untransformed_values[scoped_name] = untransformed_value
-                state.transformed_values[transformed_scoped_name] = transformed_value
-                # disable sampling and save cached results to store for yield dist
-
-                # once we are done with variables we can yield the value in untransformed space
-                # to the user and also increment the potential
-
-                # Important:
-                # I have no idea yet, how to make that beautiful.
-                # Here we indicate the distribution is already autotransformed nto to get in the infinite loop
-                dist.model_info["autotransformed"] = True
-
-                # 2. here decide on logdet computation, this might be effective
-                # with transformed value, but not with an untransformed one
-                # this information is stored in transform.jacobian_preference class attribute
-                # we postpone the computation of logdet as it might have some overhead
-                if transform.jacobian_preference == JacobianPreference.Forward:
-                    potential_fn = functools.partial(
-                        transform.forward_log_det_jacobian, untransformed_value
-                    )
-                    coef = -1.0
-                else:
-                    potential_fn = functools.partial(
-                        transform.inverse_log_det_jacobian, transformed_value
-                    )
-                    coef = 1.0
-                yield distributions.Potential(potential_fn, coef=coef)
-                # 3. final return+yield will return untransformed_value
-                # as it is stored in state.values
-                # Note: we need yield here to make another checks on name duplicates, etc
-                return (yield dist)
-
+    if transformed_scoped_name in state.transformed_values:
+        if (not allow_transformed_and_untransformed) and scoped_name in state.untransformed_values:
+            raise EvaluationError(
+                "Found both transformed and untransformed variables in the state: "
+                "'{} and '{}', but need exactly one".format(scoped_name, transformed_scoped_name)
+            )
         else:
-            # we gonna sample here, but logp should be computed for the transformed space
-            def model():
-                # 0. as explained above we indicate we already performed autotransform
-                dist.model_info["autotransformed"] = True
-                # 1. sample a value, as we've checked there is no state provided
-                # we need `dist.model_info["autotransformed"] = True` here not to get in a trouble
-                # the return value is not yet user facing
-                sampled_untransformed_value = yield dist
-                sampled_transformed_value = transform.forward(sampled_untransformed_value)
-                # already stored untransformed value via yield
-                # state.values[scoped_name] = sampled_untransformed_value
-                state.transformed_values[transformed_scoped_name] = sampled_transformed_value
-                # 2. increment the potential
-                if transform.jacobian_preference == JacobianPreference.Forward:
-                    potential_fn = functools.partial(
-                        transform.forward_log_det_jacobian, sampled_untransformed_value
-                    )
-                    coef = -1.0
-                else:
-                    potential_fn = functools.partial(
-                        transform.inverse_log_det_jacobian, sampled_transformed_value
-                    )
-                    coef = 1.0
-                yield distributions.Potential(potential_fn, coef=coef)
-                # 3. return value to the user
-                return sampled_untransformed_value
-
-        # return the correct generator model instead of a distribution
-        return model()
+            return make_transformed_model(dist, transform, state)
+    else:
+        return make_untransformed_model(dist, transform, state)

--- a/pymc4/flow/transformed_executor.py
+++ b/pymc4/flow/transformed_executor.py
@@ -131,11 +131,7 @@ def transform_dist_if_necessary(dist, state, *, allow_transformed_and_untransfor
 
     if transformed_scoped_name in state.transformed_values:
         if (not allow_transformed_and_untransformed) and scoped_name in state.untransformed_values:
-            raise EvaluationError(
-                "Found both transformed and untransformed variables in the state: "
-                "'{} and '{}', but need exactly one".format(scoped_name, transformed_scoped_name)
-            )
-        else:
-            return make_transformed_model(dist, transform, state)
+            state.untransformed_values.pop(scoped_name)
+        return make_transformed_model(dist, transform, state)
     else:
         return make_untransformed_model(dist, transform, state)

--- a/pymc4/flow/transformed_executor.py
+++ b/pymc4/flow/transformed_executor.py
@@ -55,17 +55,17 @@ class TransformedSamplingExecutor(SamplingExecutor):
         if transformed_scoped_name in state.transformed_values:
             # We do not sample in this if branch
 
-            # 0. do not allow ambiguity in state, make sure only one value is provided to compute logp
-            if (
-                transformed_scoped_name in state.transformed_values
-                and scoped_name in state.untransformed_values
-            ):
-                raise EvaluationError(
-                    "Found both transformed and untransformed variables in the state: "
-                    "'{} and '{}', but need exactly one".format(
-                        scoped_name, transformed_scoped_name
-                    )
-                )
+            # # 0. do not allow ambiguity in state, make sure only one value is provided to compute logp
+            # if (
+            #     transformed_scoped_name in state.transformed_values
+            #     and scoped_name in state.untransformed_values
+            # ):
+            #     raise EvaluationError(
+            #         "Found both transformed and untransformed variables in the state: "
+            #         "'{} and '{}', but need exactly one".format(
+            #             scoped_name, transformed_scoped_name
+            #         )
+            #     )
 
             def model():
                 # 1. now compute all the variables: in the transformed and untransformed space

--- a/pymc4/forward_sampling.py
+++ b/pymc4/forward_sampling.py
@@ -266,7 +266,7 @@ def sample_posterior_predictive(
 
     # Do a single forward pass to infer the distributions core shapes and
     # default observeds
-    state = evaluate_model_posterior_predictive(model, observed=observed)[1]
+    _, state = evaluate_model_posterior_predictive(model, observed=observed)
     if var_names is None:
         var_names = list(state.posterior_predictives)
     else:

--- a/pymc4/inference/sampling.py
+++ b/pymc4/inference/sampling.py
@@ -4,6 +4,7 @@ from tensorflow_probability import mcmc
 from pymc4.coroutine_model import Model
 from pymc4 import flow
 from pymc4.inference.utils import initialize_sampling_state
+from pymc4.utils import NameParts
 
 
 def sample(
@@ -195,6 +196,9 @@ def build_logp_and_deterministic_functions(
             kwargs = dict(zip(unobserved_keys, values))
         st = flow.SamplingState.from_values(kwargs, observed_values=observed)
         _, st = flow.evaluate_model_transformed(model, state=st)
+        for transformed_name in st.transformed_values:
+            untransformed_name = NameParts.from_name(transformed_name).full_untransformed_name
+            st.deterministics[untransformed_name] = st.untransformed_values.pop(untransformed_name)
         return st.deterministics.values()
 
     return logpfn, dict(state.all_unobserved_values), deterministics_callback, deterministic_names

--- a/pymc4/inference/sampling.py
+++ b/pymc4/inference/sampling.py
@@ -168,7 +168,9 @@ def build_logp_and_deterministic_functions(
     if state is not None and observed is not None:
         raise ValueError("Can't use both `state` and `observed` arguments")
 
-    state, deterministic_names = initialize_sampling_state(model, observed=observed, state=state)
+    state, deterministic_names, transformed_names = initialize_sampling_state(
+        model, observed=observed, state=state
+    )
 
     if not state.all_unobserved_values:
         raise ValueError(

--- a/pymc4/inference/sampling.py
+++ b/pymc4/inference/sampling.py
@@ -168,9 +168,7 @@ def build_logp_and_deterministic_functions(
     if state is not None and observed is not None:
         raise ValueError("Can't use both `state` and `observed` arguments")
 
-    state, deterministic_names, transformed_names = initialize_sampling_state(
-        model, observed=observed, state=state
-    )
+    state, deterministic_names = initialize_sampling_state(model, observed=observed, state=state)
 
     if not state.all_unobserved_values:
         raise ValueError(

--- a/pymc4/inference/utils.py
+++ b/pymc4/inference/utils.py
@@ -26,7 +26,9 @@ def initialize_sampling_state(
     """
     _, state = flow.evaluate_model_transformed(model, observed=observed, state=state)
     deterministic_names = list(state.deterministics)
-    return state.as_sampling_state(), deterministic_names
+
+    state, transform_after = state.as_sampling_state()
+    return state, deterministic_names + transform_after
 
 
 def trace_to_arviz(pm4_trace, pm4_sample_stats):

--- a/pymc4/inference/utils.py
+++ b/pymc4/inference/utils.py
@@ -7,7 +7,7 @@ from .. import Model, flow
 
 def initialize_sampling_state(
     model: Model, observed: Optional[dict] = None, state: Optional[flow.SamplingState] = None
-) -> Tuple[flow.SamplingState, List[str]]:
+) -> Tuple[flow.SamplingState, List[str], List[str]]:
     """
     Initilize the model provided state and/or observed variables.
 
@@ -27,8 +27,8 @@ def initialize_sampling_state(
     _, state = flow.evaluate_model_transformed(model, observed=observed, state=state)
     deterministic_names = list(state.deterministics)
 
-    state, transform_after = state.as_sampling_state()
-    return state, deterministic_names + transform_after
+    state, transformed_names = state.as_sampling_state()
+    return state, deterministic_names, transformed_names
 
 
 def trace_to_arviz(pm4_trace, pm4_sample_stats):

--- a/pymc4/inference/utils.py
+++ b/pymc4/inference/utils.py
@@ -7,7 +7,7 @@ from .. import Model, flow
 
 def initialize_sampling_state(
     model: Model, observed: Optional[dict] = None, state: Optional[flow.SamplingState] = None
-) -> Tuple[flow.SamplingState, List[str], List[str]]:
+) -> Tuple[flow.SamplingState, List[str]]:
     """
     Initilize the model provided state and/or observed variables.
 
@@ -28,7 +28,7 @@ def initialize_sampling_state(
     deterministic_names = list(state.deterministics)
 
     state, transformed_names = state.as_sampling_state()
-    return state, deterministic_names, transformed_names
+    return state, deterministic_names + transformed_names
 
 
 def trace_to_arviz(pm4_trace, pm4_sample_stats):

--- a/pymc4/scopes.py
+++ b/pymc4/scopes.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import threading
 
 
@@ -59,7 +60,7 @@ class Scope(object):
                 yield leaf
 
     @classmethod
-    def variable_name(cls, name):
+    def variable_name(cls, name: str) -> Optional[str]:
         """
         Generate PyMC4 variable name based on name scope we are currently in.
 
@@ -92,6 +93,10 @@ class Scope(object):
         else:
             return value
 
+    @classmethod
+    def transformed_variable_name(cls, transform_name: str, name: str) -> Optional[str]:
+        return cls.variable_name("__{}_{}".format(transform_name, name))
+
     def __repr__(self):
         return "Scope({})".format(self.__dict__)
 
@@ -101,3 +106,4 @@ def name_scope(name):
 
 
 variable_name = Scope.variable_name
+transformed_variable_name = Scope.transformed_variable_name

--- a/tests/test_8schools.py
+++ b/tests/test_8schools.py
@@ -22,7 +22,8 @@ def schools_pm4():
 
 
 def test_model_logp():
-    """
+    """Make sure log probability matches standard.
+
     Recreate this with
 
     ```python

--- a/tests/test_8schools.py
+++ b/tests/test_8schools.py
@@ -1,5 +1,8 @@
 import pymc4 as pm4
 import numpy as np
+import tensorflow as tf
+
+from numpy.testing import assert_almost_equal
 
 J = 8
 y = np.array([28, 8, -3, 7, -1, 1, 18, 12], dtype=np.float32)
@@ -18,9 +21,51 @@ def schools_pm4():
     return obs
 
 
+def test_model_logp():
+    """
+    Recreate this with
+
+    ```python
+    import pymc3 as pm
+    import numpy as np
+
+    J = 8
+    y = np.array([28, 8, -3, 7, -1, 1, 18, 12])
+    sigma = np.array([15, 10, 16, 11, 9, 11, 10, 18])
+
+
+    with pm.Model() as eight_schools:
+        eta = pm.Normal("eta", 0, 1, shape=J)
+        mu = pm.Normal("mu", 1, 10)
+        tau = pm.HalfNormal("tau", 2.0)
+
+        theta = mu + tau * eta
+
+        pm.Normal("obs", theta, sigma, observed=y)
+
+    print(eight_schools.logp({'eta': np.zeros(8), 'mu': 0, 'tau_log__': 1}).astype(np.float32))
+    ```
+    """
+    logp, *_ = pm4.inference.sampling.build_logp_and_deterministic_functions(
+        schools_pm4(), observed={"obs": y}, state=None
+    )
+    init_value = logp(
+        **{
+            "schools_pm4/eta": tf.zeros(8),
+            "schools_pm4/mu": tf.zeros(()),
+            "schools_pm4/__log_tau": tf.ones(()),
+        }
+    ).numpy()
+
+    assert_almost_equal(init_value, -42.876_114)
+
+
 def test_sample_no_xla():
     # TODO: better test, compare to a golden standard chain from pymc3,
     #   for now it is only to verify it is runnable
-    tf_trace = pm4.inference.sampling.sample(
-        schools_pm4(), step_size=0.28, num_chains=4, num_samples=100, burn_in=50, xla=False
+    chains, samples = 4, 100
+    trace, stats = pm4.inference.sampling.sample(
+        schools_pm4(), step_size=0.28, num_chains=chains, num_samples=samples, burn_in=50, xla=False
     )
+    for var_name in ("eta", "mu", "tau", "__log_tau"):
+        assert f"schools_pm4/{var_name}" in trace.keys()

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -403,7 +403,7 @@ def test_observed_cant_mix_with_transformed_and_raises_an_error(transformed_mode
 
 def test_as_sampling_state_works_observed_is_constrained(complex_model_with_observed):
     _, state = pm.evaluate_model(complex_model_with_observed())
-    sampling_state = state.as_sampling_state()
+    sampling_state, _ = state.as_sampling_state()
     assert not sampling_state.transformed_values
     assert set(sampling_state.observed_values) == {"complex_model/a/n"}
     assert set(sampling_state.untransformed_values) == {"complex_model/n"}
@@ -413,7 +413,7 @@ def test_as_sampling_state_works_observed_is_set_to_none(complex_model_with_obse
     _, state = pm.evaluate_model_transformed(
         complex_model_with_observed(), observed={"complex_model/a/n": None}
     )
-    sampling_state = state.as_sampling_state()
+    sampling_state, _ = state.as_sampling_state()
     assert set(sampling_state.transformed_values) == {"complex_model/a/__log_n"}
     assert not sampling_state.observed_values
     assert set(sampling_state.untransformed_values) == {"complex_model/n"}
@@ -421,7 +421,7 @@ def test_as_sampling_state_works_observed_is_set_to_none(complex_model_with_obse
 
 def test_as_sampling_state_works_if_transformed_exec(complex_model_with_observed):
     _, state = pm.evaluate_model_transformed(complex_model_with_observed())
-    sampling_state = state.as_sampling_state()
+    sampling_state, _ = state.as_sampling_state()
     assert not sampling_state.transformed_values
     assert set(sampling_state.observed_values) == {"complex_model/a/n"}
     assert set(sampling_state.untransformed_values) == {"complex_model/n"}

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -57,17 +57,7 @@ def unvectorized_model(request):
     return unvectorized_model, norm_shape, observed, batch_size
 
 
-@pytest.fixture(
-    scope="module",
-    params=[
-        pytest.param(
-            "XLA",
-            marks=pytest.mark.xfail(reason="XLA compilation in sample is not fully supported yet"),
-        ),
-        "noXLA",
-    ],
-    ids=str,
-)
+@pytest.fixture(scope="module", params=["XLA", "noXLA"], ids=str)
 def xla_fixture(request):
     return request.param == "XLA"
 


### PR DESCRIPTION
So this effectively adds the transformed variables back to the stack of deterministics. It caused an error in `sample_posterior_predictive`, but if I just... ignore the error, everything seems to work fine. In particular tests pass.

I am going to look at this more later, just wanted to show some WIP.

Some unrelated whitespace changes and debugging got in as well that I'll remove.