### PR TITLE
Remove Python 3.5 classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ LICENSE = "Apache License, Version 2.0"
 CLASSIFIERS = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
Looking at [the CI pipeline](https://github.com/pymc-devs/pymc4/blob/master/azure-pipelines.yml#L8-L11), we don't test against Python 3.5, so we should remove it from the PyPI classifiers.