### PR TITLE
Add meta executor

### DIFF
--- a/pymc4/__init__.py
+++ b/pymc4/__init__.py
@@ -5,7 +5,12 @@ from .scopes import name_scope, variable_name
 from . import coroutine_model
 from . import distributions
 from . import flow
-from .flow import evaluate_model_transformed, evaluate_model, evaluate_model_posterior_predictive
+from .flow import (
+    evaluate_model_transformed,
+    evaluate_model,
+    evaluate_model_posterior_predictive,
+    evaluate_meta_model,
+)
 from .coroutine_model import Model, model
 from . import inference
 from .distributions import *

--- a/pymc4/__init__.py
+++ b/pymc4/__init__.py
@@ -10,6 +10,7 @@ from .flow import (
     evaluate_model,
     evaluate_model_posterior_predictive,
     evaluate_meta_model,
+    evaluate_meta_posterior_predictive_model,
 )
 from .coroutine_model import Model, model
 from . import inference

--- a/pymc4/distributions/distribution.py
+++ b/pymc4/distributions/distribution.py
@@ -123,6 +123,24 @@ class Distribution(Model):
         """
         return self.sample(sample_shape, seed).numpy()
 
+    def test_sample(self, sample_shape=(), seed=None):
+        """Get the test value using a function signature similar to meth:`~.sample`
+        
+        Parameters
+        ----------
+        sample_shape : tuple
+            sample shape
+        seed : int | None
+            ignored. Is only present to match the signature of meth:`~.sample`
+        
+        Returns
+        -------
+        The distribution's ``test_value`` broadcasted to
+        ``sample_shape + self.batch_shape + self.event_shape``
+        """
+        sample_shape = tf.TensorShape(sample_shape)
+        return tf.broadcast_to(self.test_value, sample_shape + self.batch_shape + self.event_shape)
+
     def log_prob(self, value):
         """Return log probability as tensor."""
         return self._distribution.log_prob(value)

--- a/pymc4/distributions/distribution.py
+++ b/pymc4/distributions/distribution.py
@@ -123,7 +123,7 @@ class Distribution(Model):
         """
         return self.sample(sample_shape, seed).numpy()
 
-    def test_sample(self, sample_shape=(), seed=None):
+    def get_test_sample(self, sample_shape=(), seed=None):
         """Get the test value using a function signature similar to meth:`~.sample`
         
         Parameters

--- a/pymc4/flow/__init__.py
+++ b/pymc4/flow/__init__.py
@@ -2,16 +2,20 @@
 from .executor import SamplingExecutor, SamplingState
 from .transformed_executor import TransformedSamplingExecutor
 from .posterior_predictive_executor import PosteriorPredictiveSamplingExecutor
+from .meta_executor import MetaSamplingExecutor
 
 __all__ = [
     "SamplingExecutor",
     "TransformedSamplingExecutor",
     "PosteriorPredictiveSamplingExecutor",
+    "MetaSamplingExecutor",
     "evaluate_model",
     "evaluate_model_transformed",
     "evaluate_model_posterior_predictive",
+    "evaluate_meta_model",
 ]
 
 evaluate_model = SamplingExecutor()
 evaluate_model_transformed = TransformedSamplingExecutor()
 evaluate_model_posterior_predictive = PosteriorPredictiveSamplingExecutor()
+evaluate_meta_model = MetaSamplingExecutor()

--- a/pymc4/flow/__init__.py
+++ b/pymc4/flow/__init__.py
@@ -2,20 +2,23 @@
 from .executor import SamplingExecutor, SamplingState
 from .transformed_executor import TransformedSamplingExecutor
 from .posterior_predictive_executor import PosteriorPredictiveSamplingExecutor
-from .meta_executor import MetaSamplingExecutor
+from .meta_executor import MetaSamplingExecutor, MetaPosteriorPredictiveSamplingExecutor
 
 __all__ = [
     "SamplingExecutor",
     "TransformedSamplingExecutor",
     "PosteriorPredictiveSamplingExecutor",
     "MetaSamplingExecutor",
+    "MetaPosteriorPredictiveSamplingExecutor",
     "evaluate_model",
     "evaluate_model_transformed",
     "evaluate_model_posterior_predictive",
     "evaluate_meta_model",
+    "evaluate_meta_posterior_predictive_model",
 ]
 
 evaluate_model = SamplingExecutor()
 evaluate_model_transformed = TransformedSamplingExecutor()
 evaluate_model_posterior_predictive = PosteriorPredictiveSamplingExecutor()
 evaluate_meta_model = MetaSamplingExecutor()
+evaluate_meta_posterior_predictive_model = MetaPosteriorPredictiveSamplingExecutor()

--- a/pymc4/flow/meta_executor.py
+++ b/pymc4/flow/meta_executor.py
@@ -17,13 +17,14 @@ from pymc4.flow.executor import (
     assert_values_compatible_with_distribution,
 )
 from pymc4.flow.transformed_executor import TransformedSamplingExecutor
+from pymc4.flow.posterior_predictive_executor import PosteriorPredictiveSamplingExecutor
 
 
-__all__ = ["MetaSamplingExecutor"]
+__all__ = ["MetaSamplingExecutor", "MetaPosteriorPredictiveSamplingExecutor"]
 
 
 class MetaSamplingExecutor(TransformedSamplingExecutor):
-    """Perform inference in an unconstrained space."""
+    """Do a forward pass through the model only using distribution test values."""
 
     def proceed_distribution(
         self,
@@ -87,3 +88,15 @@ class MetaSamplingExecutor(TransformedSamplingExecutor):
                 return_value = state.untransformed_values[scoped_name] = dist.test_sample()
         state.distributions[scoped_name] = dist
         return return_value, state
+
+
+class MetaPosteriorPredictiveSamplingExecutor(
+    MetaSamplingExecutor, PosteriorPredictiveSamplingExecutor
+):
+    """Do a forward pass through the model only using distribution test values.
+    
+    Also modify the distributions to make them suitable for posterior predictive sampling.
+    """
+
+    # Everything is done in the parent classes
+    pass

--- a/pymc4/flow/meta_executor.py
+++ b/pymc4/flow/meta_executor.py
@@ -1,0 +1,89 @@
+"""Execute graph with test values to extract a model's meta-information.
+
+Specifically, we wish to extract:
+
+- All variable's core shapes
+- All observed, deterministic, and unobserved variables (both transformed and
+untransformed.
+"""
+from typing import Tuple, Any, Union
+import tensorflow as tf
+from pymc4 import scopes
+from pymc4.distributions import distribution
+from pymc4.flow.executor import (
+    SamplingState,
+    EvaluationError,
+    observed_value_in_evaluation,
+    assert_values_compatible_with_distribution,
+)
+from pymc4.flow.transformed_executor import TransformedSamplingExecutor
+
+
+__all__ = ["MetaSamplingExecutor"]
+
+
+class MetaSamplingExecutor(TransformedSamplingExecutor):
+    """Perform inference in an unconstrained space."""
+
+    def proceed_distribution(
+        self,
+        dist: distribution.Distribution,
+        state: SamplingState,
+        sample_shape: Union[int, Tuple[int], tf.TensorShape] = None,
+    ) -> Tuple[Any, SamplingState]:
+        if dist.is_anonymous:
+            raise EvaluationError("Attempting to create an anonymous Distribution")
+        scoped_name = scopes.variable_name(dist.name)
+        if scoped_name is None:
+            raise EvaluationError("Attempting to create an anonymous Distribution")
+
+        if scoped_name in state.distributions or scoped_name in state.deterministics:
+            raise EvaluationError(
+                "Attempting to create a duplicate variable {!r}, "
+                "this may happen if you forget to use `pm.name_scope()` when calling same "
+                "model/function twice without providing explicit names. If you see this "
+                "error message and the function being called is not wrapped with "
+                "`pm.model`, you should better wrap it to provide explicit name for this model".format(
+                    scoped_name
+                )
+            )
+        if scoped_name in state.observed_values or dist.is_observed:
+            observed_variable = observed_value_in_evaluation(scoped_name, dist, state)
+            if observed_variable is None:
+                # None indicates we pass None to the state.observed_values dict,
+                # might be posterior predictive or programmatically override to exchange observed variable to latent
+                if scoped_name not in state.untransformed_values:
+                    # posterior predictive
+                    if dist.is_root:
+                        return_value = state.untransformed_values[scoped_name] = dist.test_sample(
+                            sample_shape=sample_shape
+                        )
+                    else:
+                        return_value = state.untransformed_values[scoped_name] = dist.test_sample()
+                else:
+                    # replace observed variable with a custom one
+                    return_value = state.untransformed_values[scoped_name]
+                # We also store the name in posterior_predictives just to keep
+                # track of the variables used in posterior predictive sampling
+                state.posterior_predictives.add(scoped_name)
+                state.observed_values.pop(scoped_name)
+            else:
+                if scoped_name in state.untransformed_values:
+                    raise EvaluationError(
+                        EvaluationError.OBSERVED_VARIABLE_IS_NOT_SUPPRESSED_BUT_ADDITIONAL_VALUE_PASSED.format(
+                            scoped_name
+                        )
+                    )
+                assert_values_compatible_with_distribution(scoped_name, observed_variable, dist)
+                return_value = state.observed_values[scoped_name] = observed_variable
+        elif scoped_name in state.untransformed_values:
+            return_value = state.untransformed_values[scoped_name]
+        else:
+            if dist.is_root:
+                return_value = state.untransformed_values[scoped_name] = dist.test_sample(
+                    sample_shape=sample_shape
+                )
+            else:
+                return_value = state.untransformed_values[scoped_name] = dist.test_sample()
+        state.distributions[scoped_name] = dist
+        return return_value, state

--- a/pymc4/flow/meta_executor.py
+++ b/pymc4/flow/meta_executor.py
@@ -56,11 +56,13 @@ class MetaSamplingExecutor(TransformedSamplingExecutor):
                 if scoped_name not in state.untransformed_values:
                     # posterior predictive
                     if dist.is_root:
-                        return_value = state.untransformed_values[scoped_name] = dist.get_test_sample(
-                            sample_shape=sample_shape
-                        )
+                        return_value = state.untransformed_values[
+                            scoped_name
+                        ] = dist.get_test_sample(sample_shape=sample_shape)
                     else:
-                        return_value = state.untransformed_values[scoped_name] = dist.get_test_sample()
+                        return_value = state.untransformed_values[
+                            scoped_name
+                        ] = dist.get_test_sample()
                 else:
                     # replace observed variable with a custom one
                     return_value = state.untransformed_values[scoped_name]

--- a/pymc4/flow/meta_executor.py
+++ b/pymc4/flow/meta_executor.py
@@ -56,11 +56,11 @@ class MetaSamplingExecutor(TransformedSamplingExecutor):
                 if scoped_name not in state.untransformed_values:
                     # posterior predictive
                     if dist.is_root:
-                        return_value = state.untransformed_values[scoped_name] = dist.test_sample(
+                        return_value = state.untransformed_values[scoped_name] = dist.get_test_sample(
                             sample_shape=sample_shape
                         )
                     else:
-                        return_value = state.untransformed_values[scoped_name] = dist.test_sample()
+                        return_value = state.untransformed_values[scoped_name] = dist.get_test_sample()
                 else:
                     # replace observed variable with a custom one
                     return_value = state.untransformed_values[scoped_name]
@@ -81,11 +81,11 @@ class MetaSamplingExecutor(TransformedSamplingExecutor):
             return_value = state.untransformed_values[scoped_name]
         else:
             if dist.is_root:
-                return_value = state.untransformed_values[scoped_name] = dist.test_sample(
+                return_value = state.untransformed_values[scoped_name] = dist.get_test_sample(
                     sample_shape=sample_shape
                 )
             else:
-                return_value = state.untransformed_values[scoped_name] = dist.test_sample()
+                return_value = state.untransformed_values[scoped_name] = dist.get_test_sample()
         state.distributions[scoped_name] = dist
         return return_value, state
 

--- a/pymc4/inference/utils.py
+++ b/pymc4/inference/utils.py
@@ -24,7 +24,7 @@ def initialize_sampling_state(
     deterministic_names: List[str]
         The list of names of the model's deterministics
     """
-    _, state = flow.evaluate_model_transformed(model, observed=observed, state=state)
+    _, state = flow.evaluate_meta_model(model, observed=observed, state=state)
     deterministic_names = list(state.deterministics)
 
     state, transformed_names = state.as_sampling_state()

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -335,7 +335,6 @@ def test_rvs_test_point_are_valid(tf_seed, distribution_conditions):
     dist = dist_class(name=distribution_name, **conditions)
     test_value = dist.test_value
     test_sample = dist.sample()
-    print(test_value, test_sample)
     logp = dist.log_prob(test_value).numpy()
     assert test_value.shape == test_sample.shape
     assert tuple(test_value.shape.as_list()) == tuple(

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -730,5 +730,5 @@ def test_meta_executor(deterministics_in_nested_models, fixture_batch_shapes):
         dist = state.distributions[rv_name]
         sample_shape = fixture_batch_shapes if dist.is_root else ()
         np.testing.assert_allclose(
-            value.numpy(), dist.test_sample(sample_shape=sample_shape).numpy()
+            value.numpy(), dist.get_test_sample(sample_shape=sample_shape).numpy()
         )

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -157,7 +157,7 @@ def deterministics_in_nested_models():
 
     @pm.model
     def outer_model():
-        cond = yield pm.HalfNormal("cond", 1)
+        cond = yield pm.HalfNormal("cond", 1, conditionally_independent=True)
         dcond = yield pm.Deterministic("dcond", cond * 2)
         dx = yield nested_model(dcond)
         ddx = yield pm.Deterministic("ddx", dx)
@@ -707,3 +707,28 @@ def test_executor_on_conditionally_independent(fixture_batch_shapes):
     _, state = pm.evaluate_model(model(), sample_shape=fixture_batch_shapes)
     assert state.untransformed_values["model/a"].shape == fixture_batch_shapes
     assert state.untransformed_values["model/b"].shape == fixture_batch_shapes
+
+
+def test_meta_executor(deterministics_in_nested_models, fixture_batch_shapes):
+    (
+        model,
+        expected_untransformed,
+        expected_transformed,
+        expected_deterministics,
+        deterministic_mapping,
+    ) = deterministics_in_nested_models
+    _, state = pm.evaluate_meta_model(model(), sample_shape=fixture_batch_shapes)
+    assert set(state.untransformed_values) == set(expected_untransformed)
+    assert set(state.transformed_values) == set(expected_transformed)
+    assert set(state.deterministics) == set(expected_deterministics)
+    for deterministic, (inputs, op) in deterministic_mapping.items():
+        np.testing.assert_allclose(
+            state.deterministics[deterministic],
+            op(*[state.untransformed_values[i] for i in inputs]),
+        )
+    for rv_name, value in state.untransformed_values.items():
+        dist = state.distributions[rv_name]
+        sample_shape = fixture_batch_shapes if dist.is_root else ()
+        np.testing.assert_allclose(
+            value.numpy(), dist.test_sample(sample_shape=sample_shape).numpy()
+        )


### PR DESCRIPTION
This PR closes #167.

It adds the `MetaSamplingExecutor` and `MetaPosteriorPredictiveSamplingExecutor`, that work exactly the same as the previous executors but use `distribution.test_sample` instead of `distribution.sample`. This will allow us to use `Flat` and `HalfFlat` distributions in our models and still be able to `pm.sample` and `pm.sample_posterior_predictive` from them.