### PR TITLE
Add Truncated Normal distribution

### DIFF
--- a/pymc4/distributions/continuous.py
+++ b/pymc4/distributions/continuous.py
@@ -1119,6 +1119,7 @@ class Triangular(BoundedContinuousDistribution):
     def upper_limit(self):
         return self.conditions["high"]
 
+
 class TruncatedNormal(ContinuousDistribution):
     r"""Univariate truncated normal random variable.
 
@@ -1209,12 +1210,13 @@ class TruncatedNormal(ContinuousDistribution):
         loc, scale = conditions["loc"], conditions["scale"]
         low, high = conditions["low"], conditions["high"]
         return tfd.TruncatedNormal(loc=loc, scale=scale, low=low, high=high, validate_args=True)
-    
+
     def lower_limit(self):
         return self.conditions["low"]
 
     def upper_limit(self):
         return self.conditions["high"]
+
 
 class Uniform(BoundedContinuousDistribution):
     r"""Continuous uniform random variable.

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -262,6 +262,15 @@ _distribution_conditions = {
             "peak": np.array([0.5, 0.5], dtype="float32"),
         },
     },
+    "TruncatedNormal": {
+        "scalar_parameters": {"loc": 0.0, "scale": 1.0, "low": 0.0, "high": 2.0},
+        "multidim_parameters": {
+            "loc": np.array([0.0, 0.0], dtype="float32"),
+            "scale": np.array([1.0, 1.0], dtype="float32"),
+            "low": np.array([0.0, 0.0]),
+            "high": np.array([2.0, 2.0]),
+        },
+    },
     "Uniform": {
         "scalar_parameters": {"low": 0.0, "high": 1.0},
         "multidim_parameters": {


### PR DESCRIPTION
I was looking to contribute to PyMC4 and based on #44 I thought I would add the discrete Truncated Normal distribution for a start. When I looked at the source it seems to me that the Truncated Normal distribution is not available either.

This is my first contribution to PyMC so please let me know if there are any particular tests you'd like me to add and if something needs to be fixed in the PR.