### PR TITLE
Fixed typos in utils.py and flow/executor.py

### DIFF
--- a/pymc4/flow/executor.py
+++ b/pymc4/flow/executor.py
@@ -311,8 +311,9 @@ class SamplingExecutor:
         if isinstance(return_object, MODEL_POTENTIAL_AND_DETERMINISTIC_TYPES):
             raise EvaluationError(
                 "Return values should not contain instances of "
-                "apm.coroutine_model.Model`, "
-                "`types.GeneratorType` "
+                "a `pm.coroutine_model.Model`, "
+                "`types.GeneratorType`, "
+                "`pm.distributions.Deterministic`, "
                 "and `pm.distributions.Potential`. "
                 "To fix the error you should change the return statement to something like\n"
                 "    ..."

--- a/pymc4/utils.py
+++ b/pymc4/utils.py
@@ -23,11 +23,11 @@ def map_nested(fn, structure, cond=lambda obj: True):
             return fn(obj)
         return obj
 
-    # After map_nested is called, a inner_map cell will exist. This cell
+    # After map_nested is called, an inner_map cell will exist. This cell
     # has a reference to the actual function inner_map, which has references
-    # to a closure that has a reference to the inner_map cell (because the
-    # fn is recursive). To avoid this reference cycle, we set the function to
-    # None, clearing the cell
+    # to a closure that has a reference to the inner_map cell (because
+    # inner_map is a recursive function). To avoid this reference cycle, we set the function to
+    # None, clearing the cell.
     try:
         return inner_map(structure)
     finally:


### PR DESCRIPTION
Summary of changes - 
- Added `pm.distributions.Deterministic` to `validate_return_object` function.
- Changed the word `fn` [here](https://github.com/pymc-devs/pymc4/blob/master/pymc4/utils.py#L29) to be more specific as it is one of the arguments name.