### PR TITLE
Fix call to NAME_ERROR_MESSAGE in utils.py

### DIFF
--- a/pymc4/utils.py
+++ b/pymc4/utils.py
@@ -125,7 +125,7 @@ class NameParts:
         path, original_name = split[:-1], split[-1]
         match = cls.NAME_RE.match(original_name)
         if not cls.is_valid_name(name):
-            raise ValueError(cls.NAME_ERROR_MESSAGE)
+            raise ValueError(cls.NAME_ERROR_MESSAGE.format(name))
         return cls(path, match["transform"], match["name"])
 
     @property


### PR DESCRIPTION
ValueError does not display the string against which regex is matched.
```python
>>> import pymc4 as pm
>>> name = pm.utils.NameParts.from_name('_log_Normal')  # single '_'
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/user/Desktop/pymc/pymc4/pymc4/utils.py", line 128, in from_name
    raise ValueError(cls.NAME_ERROR_MESSAGE)
ValueError: Invalid name: `{}`, the correct one should look like: `__transform_name` or `name`, note only one underscore between the transform and actual name
```