### PR TITLE
Update gast to be work with tp-nightly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 arviz>=0.5.1
-gast==0.3.2
+gast>=0.3.2
 tf-nightly
 tfp-nightly
 pymc3


### PR DESCRIPTION
Tensorflow nightly has been updated to gast==0.3.3 which breaks fresh installs. 