### PR TITLE
Replace 'conditions' with members of TFP distribution

### DIFF
--- a/pymc4/distributions/continuous.py
+++ b/pymc4/distributions/continuous.py
@@ -968,13 +968,13 @@ class Pareto(BoundedContinuousDistribution):
         return float("inf")
 
     def lower_limit(self):
-        return self.conditions["scale"]
+        return self._distribution.scale
 
     @property
     def test_value(self):
         return (
             tf.zeros(self.batch_shape + self.event_shape, dtype=self.dtype)
-            + self.conditions["scale"]
+            + self._distribution.scale
             + 1
         )
 
@@ -1107,10 +1107,10 @@ class Triangular(BoundedContinuousDistribution):
         return tfd.Triangular(low=low, high=high, peak=peak)
 
     def lower_limit(self):
-        return self.conditions["low"]
+        return self._distribution.low
 
     def upper_limit(self):
-        return self.conditions["high"]
+        return self._distribution.high
 
 
 class Uniform(BoundedContinuousDistribution):
@@ -1164,10 +1164,10 @@ class Uniform(BoundedContinuousDistribution):
 
     # FIXME should we rename this functions as well?
     def lower_limit(self):
-        return self.conditions["low"]
+        return self._distribution.low
 
     def upper_limit(self):
-        return self.conditions["high"]
+        return self._distribution.high
 
 
 class Flat(ContinuousDistribution):

--- a/pymc4/distributions/discrete.py
+++ b/pymc4/distributions/discrete.py
@@ -127,7 +127,7 @@ class Binomial(BoundedDiscreteDistribution):
         return 0
 
     def upper_limit(self):
-        return self.conditions["total_count"]
+        return self._distribution.total_count
 
 
 class BetaBinomial(BoundedDiscreteDistribution):
@@ -200,7 +200,7 @@ class BetaBinomial(BoundedDiscreteDistribution):
         return 0
 
     def upper_limit(self):
-        return self.conditions["total_count"]
+        return self._distribution.total_count
 
 
 class DiscreteUniform(BoundedDiscreteDistribution):
@@ -252,10 +252,10 @@ class DiscreteUniform(BoundedDiscreteDistribution):
         return tfd.FiniteDiscrete(outcomes, probs=outcomes / (high - low))
 
     def lower_limit(self):
-        return self.conditions["low"]
+        return self._distribution.outcomes[0].numpy()
 
     def upper_limit(self):
-        return self.conditions["high"]
+        return self._distribution.outcomes[-1].numpy()
 
 
 class Categorical(BoundedDiscreteDistribution):
@@ -304,7 +304,7 @@ class Categorical(BoundedDiscreteDistribution):
         return 0
 
     def upper_limit(self):
-        return len(self.conditions["probs"])
+        return len(self._distribution.probs)
 
 
 class Geometric(BoundedDiscreteDistribution):


### PR DESCRIPTION
Hello, 

this PR changes the call of `self.conditions` to `self._distribution` in bounded distribution functions (discussed here: https://github.com/pymc-devs/pymc4/pull/252).

Cheers,
Simon