### PR TITLE
Add support for Moyal distribution

### DIFF
--- a/pymc4/distributions/continuous.py
+++ b/pymc4/distributions/continuous.py
@@ -992,7 +992,7 @@ class Moyal(ContinuousDistribution):
         import numpy as np
         import scipy.stats as st
         plt.style.use('arviz-darkgrid')
-        x = np.linspace(-5, 5, 1000)
+        x = np.linspace(-5, 10, 1000)
         locs = [0., 0., 0., -2.]
         scales = [0.5, 0.6, 1., 1.]
         for loc, scale in zip(locs, scales):

--- a/pymc4/distributions/continuous.py
+++ b/pymc4/distributions/continuous.py
@@ -128,7 +128,7 @@ class GeneralizedNormal(ContinuousDistribution):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        plt.style.use('arviz-darkgrid')
         x = np.linspace(-4, 4, 1000)
         shapes = [0.4, 1., 2., 8.]
         for shape in shapes:

--- a/pymc4/distributions/continuous.py
+++ b/pymc4/distributions/continuous.py
@@ -1018,10 +1018,9 @@ class Moyal(ContinuousDistribution):
 
     Examples
     --------
-    .. code-block:: python
-        @pm.model
-        def model():
-            x = pm.Moyal('x', loc=0, scale=10)
+    >>> @pm.model
+    ... def model():
+    ...     x = pm.Moyal('x', loc=0, scale=10)
     """
 
     def __init__(self, name, loc, scale, **kwargs):

--- a/pymc4/distributions/continuous.py
+++ b/pymc4/distributions/continuous.py
@@ -32,6 +32,7 @@ __all__ = [
     "LogNormal",
     "Logistic",
     "LogitNormal",
+    "Moyal",
     "Normal",
     "Pareto",
     "StudentT",
@@ -972,6 +973,64 @@ class LogNormal(PositiveContinuousDistribution):
     def _init_distribution(conditions):
         loc, scale = conditions["loc"], conditions["scale"]
         return tfd.LogNormal(loc=loc, scale=scale)
+
+
+class Moyal(ContinuousDistribution):
+    r"""Continuous Moyal random variable.
+
+    The pdf of this distribution is
+
+    .. math::
+
+        f(x \mid \mu, \sigma) = 
+           \frac{1}{\sqrt{2\pi}\sigma}
+           \exp\left(-\frac{1}{2}\left[\frac{x-\mu}{\sigma}+\exp\left(-\frac{x-\mu}{\sigma}\right)\right]\right)
+
+    .. plot::
+
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import scipy.stats as st
+        plt.style.use('arviz-darkgrid')
+        x = np.linspace(-5, 5, 1000)
+        locs = [0., 0., 0., -2.]
+        scales = [0.5, 0.6, 1., 1.]
+        for loc, scale in zip(locs, scales):
+            pdf = st.moyal.pdf(x, loc, scale)
+            plt.plot(x, pdf, label=r'$\mu$ = {}, $\sigma$ = {}'.format(loc, scale))
+        plt.xlabel('x', fontsize=12)
+        plt.ylabel('f(x)', fontsize=12)
+        plt.legend(loc=1)
+        plt.show()
+
+    ========  ==========================================
+    Support   :math:`x \in \mathbb{R}`
+    Mean      :math:`\mu+\sigma(\gamma+ln(2))` where \gamma is the Euler-Mascheroni constant
+    Variance  :math:`\dfrac{\pi^2\sigma^2}{2}`
+    ========  ==========================================
+
+    Parameters
+    ----------
+    loc : float
+        Location parameter.
+    scale : float
+        Scale parameter.
+
+    Examples
+    --------
+    .. code-block:: python
+        @pm.model
+        def model():
+            x = pm.Moyal('x', loc=0, scale=10)
+    """
+
+    def __init__(self, name, loc, scale, **kwargs):
+        super().__init__(name, loc=loc, scale=scale, **kwargs)
+
+    @staticmethod
+    def _init_distribution(conditions):
+        loc, scale = conditions["loc"], conditions["scale"]
+        return tfd.Moyal(loc=loc, scale=scale)
 
 
 class Pareto(BoundedContinuousDistribution):

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -219,6 +219,13 @@ _distribution_conditions = {
             "scale": np.array([3.0, 3.0], dtype="float32"),
         },
     },
+    "Moyal": {
+        "scalar_parameters": {"loc": 0.0, "scale": 1.0},
+        "multidim_parameters": {
+            "loc": np.array([0.0, 0.0], dtype="float32"),
+            "scale": np.array([1.0, 1.0], dtype="float32"),
+        },
+    },
     "Multinomial": {
         "scalar_parameters": {
             "total_count": 4,


### PR DESCRIPTION
add Moyal class to continuous.py.
add its test dictionary.

use arviz-darkgrid style in GeneralizedNormal.
Closes #277 