### PR TITLE
INF: Manually add build sha for codecov report

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,6 +51,6 @@ steps:
     displayName: "notebooks"
 
   - script: |
-      bash <(curl -s https://codecov.io/bash)
+      bash <(curl -s https://codecov.io/bash) -n "$(NAME)" -C $BUILD_SOURCEVERSION
     displayName: "Publish test results to codecov for Python $(python.version)"
     condition: succeededOrFailed()


### PR DESCRIPTION
Closes #232 

It looks like the codecov bash uploader broke at some point, and now cannot automatically upload the coverage reports for PRs. @OriolAbril pointed us to the workaround that is being used on arviz and I just completely copied it here.