### PR TITLE
Add a way to pass any kwarg to the underlying tfd distributions while building pm Distributions

### DIFF
--- a/pymc4/distributions/batchstack.py
+++ b/pymc4/distributions/batchstack.py
@@ -69,7 +69,7 @@ class BatchStacker(distribution_lib.Distribution):
     Example 1: Five scalar draws.
 
     >>> from tensorflow_probability import distributions as tfd
-    >>> s = tfd.BatchStacker(
+    >>> s = BatchStacker(
     ...     tfd.Normal(loc=0, scale=1),
     ...     batch_stack=5)
     >>> x = s.sample()
@@ -81,7 +81,7 @@ class BatchStacker(distribution_lib.Distribution):
     
     Example 2: `[5, 4]`-draws of a bivariate Normal.
 
-    >>> s = tfd.BatchStacker(
+    >>> s = BatchStacker(
     ...     tfd.Independent(tfd.Normal(loc=tf.zeros([3, 2]), scale=1),
     ...                     reinterpreted_batch_ndims=1),
     ...     batch_stack=[5, 4])

--- a/pymc4/distributions/continuous.py
+++ b/pymc4/distributions/continuous.py
@@ -611,6 +611,10 @@ class Gumbel(ContinuousDistribution):
         loc, scale = conditions["loc"], conditions["scale"]
         return tfd.Gumbel(loc=loc, scale=scale, **kwargs)
 
+    @property
+    def validate_args(self):
+        return self._distribution.bijector.validate_args
+
 
 class HalfCauchy(PositiveContinuousDistribution):
     r"""Half-Cauchy random variable.
@@ -784,6 +788,10 @@ class Kumaraswamy(UnitContinuousDistribution):
         return tfd.Kumaraswamy(
             concentration0=concentration0, concentration1=concentration1, **kwargs
         )
+
+    @property
+    def validate_args(self):
+        return self._distribution.bijector.validate_args
 
 
 class Laplace(ContinuousDistribution):
@@ -1033,6 +1041,10 @@ class Moyal(ContinuousDistribution):
     def _init_distribution(conditions, **kwargs):
         loc, scale = conditions["loc"], conditions["scale"]
         return tfd.Moyal(loc=loc, scale=scale, **kwargs)
+
+    @property
+    def validate_args(self):
+        return self._distribution.bijector.validate_args
 
 
 class Pareto(BoundedContinuousDistribution):
@@ -1512,5 +1524,6 @@ class Weibull(PositiveContinuousDistribution):
                 low=tf.zeros(broadcast_shape), high=tf.ones(broadcast_shape), **kwargs
             ),
             bijector=bij.Invert(bij.WeibullCDF(scale=scale, concentration=concentration)),
+            validate_args=kwargs.get("validate_args", False),
             name="Weibull",
         )

--- a/pymc4/distributions/continuous.py
+++ b/pymc4/distributions/continuous.py
@@ -107,9 +107,9 @@ class Normal(ContinuousDistribution):
         super().__init__(name, loc=loc, scale=scale, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         loc, scale = conditions["loc"], conditions["scale"]
-        return tfd.Normal(loc=loc, scale=scale)
+        return tfd.Normal(loc=loc, scale=scale, **kwargs)
 
 
 class GeneralizedNormal(ContinuousDistribution):
@@ -168,9 +168,9 @@ class GeneralizedNormal(ContinuousDistribution):
         super().__init__(name, loc=loc, scale=scale, power=power, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         loc, scale, power = conditions["loc"], conditions["scale"], conditions["power"]
-        return tfd.GeneralizedNormal(loc=loc, scale=scale, power=power)
+        return tfd.GeneralizedNormal(loc=loc, scale=scale, power=power, **kwargs)
 
 
 class HalfNormal(PositiveContinuousDistribution):
@@ -234,9 +234,9 @@ class HalfNormal(PositiveContinuousDistribution):
         super().__init__(name, scale=scale, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         scale = conditions["scale"]
-        return tfd.HalfNormal(scale=scale)
+        return tfd.HalfNormal(scale=scale, **kwargs)
 
 
 class HalfStudentT(PositiveContinuousDistribution):
@@ -295,10 +295,10 @@ class HalfStudentT(PositiveContinuousDistribution):
         super().__init__(name, df=df, scale=scale, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         scale = conditions["scale"]
         df = conditions["df"]
-        return TFPHalfStudentT(df=df, loc=0, scale=scale)
+        return TFPHalfStudentT(df=df, loc=0, scale=scale, **kwargs)
 
 
 class Beta(UnitContinuousDistribution):
@@ -354,9 +354,9 @@ class Beta(UnitContinuousDistribution):
         )
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         concentration0, concentration1 = conditions["concentration0"], conditions["concentration1"]
-        return tfd.Beta(concentration0=concentration0, concentration1=concentration1)
+        return tfd.Beta(concentration0=concentration0, concentration1=concentration1, **kwargs)
 
 
 class Cauchy(ContinuousDistribution):
@@ -407,9 +407,9 @@ class Cauchy(ContinuousDistribution):
         super().__init__(name, loc=loc, scale=scale, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         loc, scale = conditions["loc"], conditions["scale"]
-        return tfd.Cauchy(loc=loc, scale=scale)
+        return tfd.Cauchy(loc=loc, scale=scale, **kwargs)
 
 
 class Chi2(PositiveContinuousDistribution):
@@ -453,9 +453,9 @@ class Chi2(PositiveContinuousDistribution):
         super().__init__(name, df=df, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         df = conditions["df"]
-        return tfd.Chi2(df=df)
+        return tfd.Chi2(df=df, **kwargs)
 
 
 class Exponential(PositiveContinuousDistribution):
@@ -498,9 +498,9 @@ class Exponential(PositiveContinuousDistribution):
         super().__init__(name, rate=rate, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         rate = conditions["rate"]
-        return tfd.Exponential(rate=rate)
+        return tfd.Exponential(rate=rate, **kwargs)
 
 
 class Gamma(PositiveContinuousDistribution):
@@ -551,9 +551,9 @@ class Gamma(PositiveContinuousDistribution):
         super().__init__(name, concentration=concentration, rate=rate, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         concentration, rate = conditions["concentration"], conditions["rate"]
-        return tfd.Gamma(concentration=concentration, rate=rate)
+        return tfd.Gamma(concentration=concentration, rate=rate, **kwargs)
 
 
 class Gumbel(ContinuousDistribution):
@@ -607,9 +607,9 @@ class Gumbel(ContinuousDistribution):
         super().__init__(name, loc=loc, scale=scale, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         loc, scale = conditions["loc"], conditions["scale"]
-        return tfd.Gumbel(loc=loc, scale=scale)
+        return tfd.Gumbel(loc=loc, scale=scale, **kwargs)
 
 
 class HalfCauchy(PositiveContinuousDistribution):
@@ -657,9 +657,9 @@ class HalfCauchy(PositiveContinuousDistribution):
         super().__init__(name, scale=scale, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         scale = conditions["scale"]
-        return tfd.HalfCauchy(loc=0, scale=scale)
+        return tfd.HalfCauchy(loc=0, scale=scale, **kwargs)
 
 
 class InverseGamma(PositiveContinuousDistribution):
@@ -709,9 +709,9 @@ class InverseGamma(PositiveContinuousDistribution):
         super().__init__(name, concentration=concentration, scale=scale, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         concentration, scale = conditions["concentration"], conditions["scale"]
-        return tfd.InverseGamma(concentration=concentration, scale=scale)
+        return tfd.InverseGamma(concentration=concentration, scale=scale, **kwargs)
 
 
 class InverseGaussian(PositiveContinuousDistribution):
@@ -727,9 +727,9 @@ class InverseGaussian(PositiveContinuousDistribution):
         super().__init__(name, loc=loc, concentration=concentration, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         loc, concentration = conditions["loc"], conditions["concentration"]
-        return tfd.InverseGaussian(loc=loc, concentration=concentration)
+        return tfd.InverseGaussian(loc=loc, concentration=concentration, **kwargs)
 
 
 class Kumaraswamy(UnitContinuousDistribution):
@@ -779,9 +779,11 @@ class Kumaraswamy(UnitContinuousDistribution):
         )
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         concentration0, concentration1 = conditions["concentration0"], conditions["concentration1"]
-        return tfd.Kumaraswamy(concentration0=concentration0, concentration1=concentration1)
+        return tfd.Kumaraswamy(
+            concentration0=concentration0, concentration1=concentration1, **kwargs
+        )
 
 
 class Laplace(ContinuousDistribution):
@@ -829,9 +831,9 @@ class Laplace(ContinuousDistribution):
         super().__init__(name, loc=loc, scale=scale, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         loc, scale = conditions["loc"], conditions["scale"]
-        return tfd.Laplace(loc=loc, scale=scale)
+        return tfd.Laplace(loc=loc, scale=scale, **kwargs)
 
 
 class Logistic(ContinuousDistribution):
@@ -880,9 +882,9 @@ class Logistic(ContinuousDistribution):
         super().__init__(name, loc=loc, scale=scale, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         loc, scale = conditions["loc"], conditions["scale"]
-        return tfd.Logistic(loc=loc, scale=scale)
+        return tfd.Logistic(loc=loc, scale=scale, **kwargs)
 
 
 class LogitNormal(UnitContinuousDistribution):
@@ -907,9 +909,9 @@ class LogitNormal(UnitContinuousDistribution):
         super().__init__(name, loc=loc, scale=scale, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         loc, scale = conditions["loc"], conditions["scale"]
-        return tfd.LogitNormal(loc=loc, scale=scale)
+        return tfd.LogitNormal(loc=loc, scale=scale, **kwargs)
 
 
 class LogNormal(PositiveContinuousDistribution):
@@ -970,9 +972,9 @@ class LogNormal(PositiveContinuousDistribution):
         super().__init__(name, loc=loc, scale=scale, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         loc, scale = conditions["loc"], conditions["scale"]
-        return tfd.LogNormal(loc=loc, scale=scale)
+        return tfd.LogNormal(loc=loc, scale=scale, **kwargs)
 
 
 class Moyal(ContinuousDistribution):
@@ -1018,6 +1020,7 @@ class Moyal(ContinuousDistribution):
 
     Examples
     --------
+    >>> import pymc4 as pm
     >>> @pm.model
     ... def model():
     ...     x = pm.Moyal('x', loc=0, scale=10)
@@ -1027,9 +1030,9 @@ class Moyal(ContinuousDistribution):
         super().__init__(name, loc=loc, scale=scale, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         loc, scale = conditions["loc"], conditions["scale"]
-        return tfd.Moyal(loc=loc, scale=scale)
+        return tfd.Moyal(loc=loc, scale=scale, **kwargs)
 
 
 class Pareto(BoundedContinuousDistribution):
@@ -1080,9 +1083,9 @@ class Pareto(BoundedContinuousDistribution):
         super().__init__(name, concentration=concentration, scale=scale, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         concentration, scale = conditions["concentration"], conditions["scale"]
-        return tfd.Pareto(concentration=concentration, scale=scale)
+        return tfd.Pareto(concentration=concentration, scale=scale, **kwargs)
 
     def upper_limit(self):
         return float("inf")
@@ -1160,9 +1163,9 @@ class StudentT(ContinuousDistribution):
         super().__init__(name, loc=loc, scale=scale, df=df, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         df, loc, scale = conditions["df"], conditions["loc"], conditions["scale"]
-        return tfd.StudentT(df=df, loc=loc, scale=scale)
+        return tfd.StudentT(df=df, loc=loc, scale=scale, **kwargs)
 
 
 class Triangular(BoundedContinuousDistribution):
@@ -1222,9 +1225,9 @@ class Triangular(BoundedContinuousDistribution):
         super().__init__(name, low=low, peak=peak, high=high, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         low, high, peak = conditions["low"], conditions["high"], conditions["peak"]
-        return tfd.Triangular(low=low, high=high, peak=peak)
+        return tfd.Triangular(low=low, high=high, peak=peak, **kwargs)
 
     def lower_limit(self):
         return self._distribution.low
@@ -1278,9 +1281,9 @@ class Uniform(BoundedContinuousDistribution):
         super().__init__(name, low=low, high=high, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         low, high = conditions["low"], conditions["high"]
-        return tfd.Uniform(low=low, high=high)
+        return tfd.Uniform(low=low, high=high, **kwargs)
 
     # FIXME should we rename this functions as well?
     def lower_limit(self):
@@ -1300,8 +1303,8 @@ class Flat(ContinuousDistribution):
         super().__init__(name, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
-        return tfd.Uniform(low=-np.inf, high=np.inf)
+    def _init_distribution(conditions, **kwargs):
+        return tfd.Uniform(low=-np.inf, high=np.inf, **kwargs)
 
     def log_prob(self, value):
         # convert the value to tensor
@@ -1343,8 +1346,8 @@ class HalfFlat(PositiveContinuousDistribution):
         super().__init__(name, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
-        return tfd.Uniform(low=0.0, high=np.inf)
+    def _init_distribution(conditions, **kwargs):
+        return tfd.Uniform(low=0.0, high=np.inf, **kwargs)
 
     def log_prob(self, value):
         # convert the value to tensor
@@ -1428,9 +1431,9 @@ class VonMises(BoundedContinuousDistribution):
         super().__init__(name, loc=loc, concentration=concentration, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         loc, concentration = conditions["loc"], conditions["concentration"]
-        return tfd.VonMises(loc=loc, concentration=concentration)
+        return tfd.VonMises(loc=loc, concentration=concentration, **kwargs)
 
     def lower_limit(self):
         return -math.pi
@@ -1493,8 +1496,7 @@ class Weibull(PositiveContinuousDistribution):
         super().__init__(name, concentration=concentration, scale=scale, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
-
+    def _init_distribution(conditions, **kwargs):
         concentration, scale = conditions["concentration"], conditions["scale"]
 
         scale_tensor, concentration_tensor = (
@@ -1506,7 +1508,9 @@ class Weibull(PositiveContinuousDistribution):
         )
 
         return tfd.TransformedDistribution(
-            distribution=tfd.Uniform(low=tf.zeros(broadcast_shape), high=tf.ones(broadcast_shape)),
+            distribution=tfd.Uniform(
+                low=tf.zeros(broadcast_shape), high=tf.ones(broadcast_shape), **kwargs
+            ),
             bijector=bij.Invert(bij.WeibullCDF(scale=scale, concentration=concentration)),
             name="Weibull",
         )

--- a/pymc4/distributions/discrete.py
+++ b/pymc4/distributions/discrete.py
@@ -62,9 +62,9 @@ class Bernoulli(BoundedDiscreteDistribution):
         super().__init__(name, probs=probs, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         probs = conditions["probs"]
-        return tfd.Bernoulli(probs=probs)
+        return tfd.Bernoulli(probs=probs, **kwargs)
 
     def lower_limit(self):
         return 0
@@ -119,9 +119,9 @@ class Binomial(BoundedDiscreteDistribution):
         super().__init__(name, total_count=total_count, probs=probs, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         total_count, probs = conditions["total_count"], conditions["probs"]
-        return tfd.Binomial(total_count=total_count, probs=probs)
+        return tfd.Binomial(total_count=total_count, probs=probs, **kwargs)
 
     def lower_limit(self):
         return 0
@@ -186,14 +186,17 @@ class BetaBinomial(BoundedDiscreteDistribution):
         )
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         total_count, concentration0, concentration1 = (
             conditions["total_count"],
             conditions["concentration0"],
             conditions["concentration1"],
         )
         return tfd.BetaBinomial(
-            total_count=total_count, concentration0=concentration0, concentration1=concentration1
+            total_count=total_count,
+            concentration0=concentration0,
+            concentration1=concentration1,
+            **kwargs,
         )
 
     def lower_limit(self):
@@ -246,10 +249,10 @@ class DiscreteUniform(BoundedDiscreteDistribution):
         super().__init__(name, low=low, high=high, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         low, high = conditions["low"], conditions["high"]
         outcomes = tf.range(low, high + 1)
-        return tfd.FiniteDiscrete(outcomes, probs=outcomes / (high - low))
+        return tfd.FiniteDiscrete(outcomes, probs=outcomes / (high - low), **kwargs)
 
     def lower_limit(self):
         return self._distribution.outcomes[0].numpy()
@@ -295,10 +298,10 @@ class Categorical(BoundedDiscreteDistribution):
         super().__init__(name, probs=probs, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         probs = tf.convert_to_tensor(conditions["probs"])
         outcomes = tf.range(probs.shape[-1])
-        return tfd.FiniteDiscrete(outcomes, probs=probs)
+        return tfd.FiniteDiscrete(outcomes, probs=probs, **kwargs)
 
     def lower_limit(self):
         return 0
@@ -350,9 +353,9 @@ class Geometric(BoundedDiscreteDistribution):
         super().__init__(name, probs=probs, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         probs = conditions["probs"]
-        return tfd.Geometric(probs=probs)
+        return tfd.Geometric(probs=probs, **kwargs)
 
     def lower_limit(self):
         return 1
@@ -420,9 +423,9 @@ class NegativeBinomial(PositiveDiscreteDistribution):
         super().__init__(name, total_count=total_count, probs=probs, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         total_count, probs = conditions["total_count"], conditions["probs"]
-        return tfd.NegativeBinomial(total_count=total_count, probs=probs)
+        return tfd.NegativeBinomial(total_count=total_count, probs=probs, **kwargs)
 
 
 class Poisson(PositiveDiscreteDistribution):
@@ -474,9 +477,9 @@ class Poisson(PositiveDiscreteDistribution):
         super().__init__(name, rate=rate, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         rate = conditions["rate"]
-        return tfd.Poisson(rate=rate)
+        return tfd.Poisson(rate=rate, **kwargs)
 
 
 # TODO: Implement this
@@ -707,9 +710,9 @@ class Zipf(PositiveDiscreteDistribution):
         super().__init__(name, power=power, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         power = conditions["power"]
-        return tfd.Zipf(power=power)
+        return tfd.Zipf(power=power, **kwargs)
 
 
 class OrderedLogistic(BoundedDiscreteDistribution):
@@ -743,10 +746,10 @@ class OrderedLogistic(BoundedDiscreteDistribution):
         super().__init__(name, loc=loc, cutpoints=cutpoints, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         cutpoints = tf.convert_to_tensor(conditions["cutpoints"])
         loc = conditions["loc"]
-        return tfd.OrderedLogistic(cutpoints=cutpoints, loc=loc)
+        return tfd.OrderedLogistic(cutpoints=cutpoints, loc=loc, **kwargs)
 
     def lower_limit(self):
         return 0

--- a/pymc4/distributions/discrete.py
+++ b/pymc4/distributions/discrete.py
@@ -252,7 +252,9 @@ class DiscreteUniform(BoundedDiscreteDistribution):
     def _init_distribution(conditions, **kwargs):
         low, high = conditions["low"], conditions["high"]
         outcomes = tf.range(low, high + 1)
-        return tfd.FiniteDiscrete(outcomes, probs=outcomes / (high - low), **kwargs)
+        return tfd.FiniteDiscrete(
+            outcomes, probs=tf.ones_like(outcomes) / (high + 1 - low), **kwargs
+        )
 
     def lower_limit(self):
         return self._distribution.outcomes[0].numpy()

--- a/pymc4/distributions/distribution.py
+++ b/pymc4/distributions/distribution.py
@@ -206,6 +206,18 @@ class Distribution(Model):
     def event_shape(self):
         return self._distribution.event_shape
 
+    @property
+    def dtype(self):
+        return self._distribution.dtype
+
+    @property
+    def validate_args(self):
+        return self._distribution.validate_args
+
+    @property
+    def allow_nan_stats(self):
+        return self._distribution.allow_nan_stats
+
 
 class Potential:
     __slots__ = ("_value", "_coef")

--- a/pymc4/distributions/distribution.py
+++ b/pymc4/distributions/distribution.py
@@ -1,6 +1,7 @@
 import abc
 import copy
-from typing import Optional, Union, Any
+import warnings
+from typing import Optional, Union, Any, Tuple
 
 import tensorflow as tf
 from tensorflow_probability import distributions as tfd
@@ -29,6 +30,7 @@ class Distribution(Model):
     """Statistical distribution."""
 
     _test_value = 0.0
+    _base_parameters = ["dtype", "validate_args", "allow_nan_stats"]
 
     def __init__(
         self,
@@ -40,10 +42,15 @@ class Distribution(Model):
         event_stack=None,
         conditionally_independent=False,
         reinterpreted_batch_ndims=0,
+        dtype=None,
+        validate_args=False,
+        allow_nan_stats=False,
         **kwargs,
     ):
-        self.conditions = self.unpack_conditions(**kwargs)
-        self._distribution = self._init_distribution(self.conditions)
+        self.conditions, self.base_parameters = self.unpack_conditions(
+            dtype=dtype, validate_args=validate_args, allow_nan_stats=allow_nan_stats, **kwargs
+        )
+        self._distribution = self._init_distribution(self.conditions, **self.base_parameters)
         super().__init__(
             self.unpack_distribution, name=name, keep_return=True, keep_auxiliary=False
         )
@@ -71,7 +78,7 @@ class Distribution(Model):
         return self._distribution.dtype
 
     @staticmethod
-    def _init_distribution(conditions: dict) -> tfd.Distribution:
+    def _init_distribution(conditions: dict, **kwargs) -> tfd.Distribution:
         ...
 
     def _init_transform(self, transform):
@@ -80,15 +87,19 @@ class Distribution(Model):
     def unpack_distribution(self):
         return unpack(self)
 
-    @staticmethod
-    def unpack_conditions(**kwargs) -> dict:
+    @classmethod
+    def unpack_conditions(cls, **kwargs) -> Tuple[dict, dict]:
         """
         Parse arguments.
 
         This is used to form :attr:`conditions` for a distributions, as
         one may desire to have different parametrizations, this all should be done there
         """
-        return kwargs
+        base_parameters = {k: v for k, v in kwargs.items() if k in cls._base_parameters}
+        if base_parameters["dtype"] is None:
+            del base_parameters["dtype"]
+        conditions = {k: v for k, v in kwargs.items() if k not in cls._base_parameters}
+        return conditions, base_parameters
 
     @property
     def test_value(self):
@@ -238,6 +249,18 @@ class Deterministic(Model):
 
 class ContinuousDistribution(Distribution):
     _test_value = 0.0
+
+    @classmethod
+    def unpack_conditions(cls, **kwargs):
+        conditions, base_parameters = super().unpack_conditions(**kwargs)
+        dtype = base_parameters.pop("dtype", None)
+        if dtype is not None:
+            warnings.warn(
+                f"At the moment, the continuous distributions of the backend used by pymc4 "
+                f"(tensorflow_probability) do not accept an explicit `dtype`. The supplied "
+                f"dtype={dtype} will be ignored."
+            )
+        return conditions, base_parameters
 
 
 class DiscreteDistribution(Distribution):

--- a/pymc4/distributions/distribution.py
+++ b/pymc4/distributions/distribution.py
@@ -207,10 +207,6 @@ class Distribution(Model):
         return self._distribution.event_shape
 
     @property
-    def dtype(self):
-        return self._distribution.dtype
-
-    @property
     def validate_args(self):
         return self._distribution.validate_args
 

--- a/pymc4/distributions/multivariate.py
+++ b/pymc4/distributions/multivariate.py
@@ -64,9 +64,9 @@ class Dirichlet(SimplexContinuousDistribution):
         super().__init__(name, concentration=concentration, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         concentration = conditions["concentration"]
-        return tfd.Dirichlet(concentration=concentration)
+        return tfd.Dirichlet(concentration=concentration, **kwargs)
 
 
 class LKJ(ContinuousDistribution):
@@ -108,9 +108,9 @@ class LKJ(ContinuousDistribution):
         super().__init__(name, dimension=dimension, concentration=concentration, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         dimension, concentration = conditions["dimension"], conditions["concentration"]
-        return tfd.LKJ(dimension=dimension, concentration=concentration)
+        return tfd.LKJ(dimension=dimension, concentration=concentration, **kwargs)
 
     @property
     def test_value(self):
@@ -155,9 +155,9 @@ class Multinomial(DiscreteDistribution):
         super().__init__(name, total_count=total_count, probs=probs, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         total_count, probs = conditions["total_count"], conditions["probs"]
-        return tfd.Multinomial(total_count=total_count, probs=probs)
+        return tfd.Multinomial(total_count=total_count, probs=probs, **kwargs)
 
 
 class MvNormal(ContinuousDistribution):
@@ -203,13 +203,13 @@ class MvNormal(ContinuousDistribution):
         super().__init__(name, loc=loc, covariance_matrix=covariance_matrix, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         loc, covariance_matrix = conditions["loc"], conditions["covariance_matrix"]
         try:
             chol_cov_matrix = tf.linalg.cholesky(covariance_matrix)
         except tf.errors.InvalidArgumentError:
             raise ValueError("Cholesky decomposition failed! Check your `covariance_matrix`.")
-        return tfd.MultivariateNormalTriL(loc=loc, scale_tril=chol_cov_matrix)
+        return tfd.MultivariateNormalTriL(loc=loc, scale_tril=chol_cov_matrix, **kwargs)
 
 
 class VonMisesFisher(ContinuousDistribution):
@@ -245,9 +245,11 @@ class VonMisesFisher(ContinuousDistribution):
         super().__init__(name, mean_direction=mean_direction, concentration=concentration, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         mean_direction, concentration = conditions["mean_direction"], conditions["concentration"]
-        return tfd.VonMisesFisher(mean_direction=mean_direction, concentration=concentration)
+        return tfd.VonMisesFisher(
+            mean_direction=mean_direction, concentration=concentration, **kwargs
+        )
 
 
 class Wishart(ContinuousDistribution):
@@ -286,9 +288,9 @@ class Wishart(ContinuousDistribution):
         super().__init__(name, df=df, scale=scale, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         df, scale = conditions["df"], conditions["scale"]
-        return tfd.WishartTriL(df=df, scale_tril=scale)
+        return tfd.WishartTriL(df=df, scale_tril=scale, **kwargs)
 
     @property
     def test_value(self):
@@ -327,9 +329,9 @@ class LKJCholesky(ContinuousDistribution):
         super().__init__(name, dimension=dimension, concentration=concentration, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         dimension, concentration = conditions["dimension"], conditions["concentration"]
-        return tfd.CholeskyLKJ(dimension=dimension, concentration=concentration)
+        return tfd.CholeskyLKJ(dimension=dimension, concentration=concentration, **kwargs)
 
     @property
     def test_value(self):
@@ -381,6 +383,6 @@ class MvNormalCholesky(ContinuousDistribution):
         super().__init__(name, loc=loc, scale_tril=scale_tril, **kwargs)
 
     @staticmethod
-    def _init_distribution(conditions):
+    def _init_distribution(conditions, **kwargs):
         loc, scale_tril = conditions["loc"], conditions["scale_tril"]
-        return tfd.MultivariateNormalTriL(loc=loc, scale_tril=scale_tril)
+        return tfd.MultivariateNormalTriL(loc=loc, scale_tril=scale_tril, **kwargs)

--- a/pymc4/distributions/timeseries.py
+++ b/pymc4/distributions/timeseries.py
@@ -64,7 +64,7 @@ class AR(ContinuousDistribution):
         return conditions, {}
 
     @staticmethod
-    def _init_distribution(conditions: dict, base_parameters=None):
+    def _init_distribution(conditions: dict, **kwargs):
         num_timesteps = conditions["num_timesteps"]
         coefficients = conditions["coefficients"]
         level_scale = conditions["level_scale"]

--- a/pymc4/distributions/timeseries.py
+++ b/pymc4/distributions/timeseries.py
@@ -1,3 +1,4 @@
+import warnings
 import tensorflow as tf
 from tensorflow_probability import sts
 from tensorflow_probability import distributions as tfd
@@ -52,8 +53,18 @@ class AR(ContinuousDistribution):
             **kwargs,
         )
 
+    @classmethod
+    def unpack_conditions(cls, **kwargs):
+        conditions, base_parameters = super().unpack_conditions(**kwargs)
+        warnings.warn(
+            "At the moment, the Autoregressive distribution does not accept the initialization "
+            "arguments: dtype, allow_nan_stats or validate_args. Any of those keyword arguments "
+            "passed during initialization will be ignored."
+        )
+        return conditions, {}
+
     @staticmethod
-    def _init_distribution(conditions: dict):
+    def _init_distribution(conditions: dict, base_parameters=None):
         num_timesteps = conditions["num_timesteps"]
         coefficients = conditions["coefficients"]
         level_scale = conditions["level_scale"]

--- a/pymc4/gp/gp.py
+++ b/pymc4/gp/gp.py
@@ -169,10 +169,10 @@ class LatentGP(BaseGP):
 
         Examples
         --------
-        >>> import pymc3 as pm
+        >>> import pymc4 as pm
         >>> import numpy as np
         >>> X = np.linspace(0, 1, 10)
-        >>> cov_fn = pm.gp.cov.ExpQuad(amplitude=1., ls=1.)
+        >>> cov_fn = pm.gp.cov.ExpQuad(amplitude=1., length_scale=1.)
         >>> gp = pm.gp.LatentGP(cov_fn=cov_fn)
         >>> @pm.model
         ... def gp_model():
@@ -225,11 +225,11 @@ class LatentGP(BaseGP):
 
         Examples
         --------
-        >>> import pymc3 as pm
+        >>> import pymc4 as pm
         >>> import numpy as np
         >>> X = np.linspace(0, 1, 10)
         >>> Xnew = np.linspace(0, 1, 50)
-        >>> cov_fn = pm.gp.cov.ExpQuad(amplitude=1., ls=1.)
+        >>> cov_fn = pm.gp.cov.ExpQuad(amplitude=1., length_scale=1.)
         >>> gp = pm.gp.LatentGP(cov_fn=cov_fn)
         >>> @pm.model
         ... def gp_model():

--- a/pymc4/gp/gp.py
+++ b/pymc4/gp/gp.py
@@ -245,5 +245,6 @@ class LatentGP(BaseGP):
                 name=name,
                 loc=tf.squeeze(mu, axis=[-1]),
                 scale=tf.math.sqrt(tf.squeeze(cov, axis=[-1, -2])),
+                **kwargs,
             )
         return MvNormal(name=name, loc=mu, covariance_matrix=cov, **kwargs)

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -349,7 +349,7 @@ _distribution_conditions = {
             "sample": np.array([0.0, 1.0], dtype="float32"),
         },
         "multidim_parameters": {
-            "mean_direction": np.array([[1.0, 1.0], [0.0, 1.0]], dtype="float32"),
+            "mean_direction": np.array([[1.0, 0.0], [0.0, 1.0]], dtype="float32"),
             "concentration": np.array([1.0, 1.0], dtype="float32"),
             "sample": np.array([[1.0, 1.0], [0.0, 1.0]], dtype="float32"),
         },


### PR DESCRIPTION
Closes #236 and superseeds #239.

#236 requested that we provide a way to validate the arguments that we pass onto the underlying tfp distributions. #239 did exactly that, but I think that it would be better to make the method flexible enough to be able to pass in any extra build argument that is desired (like `dtype` and `allow_nan_stats`). This didn't turn out to be as simple as I thought as first, because continuous distributions don't have a `dtype` argument in their `__init__`.

The approach I followed was to modify `unpack_conditions` in order to return the probability distribution parameters as a `conditions` dictionary, and any other kwarg as extra parameters to pass as base class build arguments.