### PR TITLE
[INF] Officially switching devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "PyMC4 Development Container",
 	"context": "..",
-	"image": "registry.hub.docker.com/ericmjl/pymc4:devcontainer",
+	"image": "registry.hub.docker.com/pymc/pymc4:devcontainer",
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash",


### PR DESCRIPTION
It used to be `ericmjl/pymc4:devcontainer`. Now changed to `pymc/pymc4:devcontainer`.