### PR TITLE
Implement mixture distribution

### DIFF
--- a/pymc4/distributions/__init__.py
+++ b/pymc4/distributions/__init__.py
@@ -3,4 +3,5 @@ from .discrete import *
 from .multivariate import *
 from .timeseries import *
 from .distribution import Potential, Deterministic
+from .mixture import Mixture
 from . import transforms

--- a/pymc4/distributions/mixture.py
+++ b/pymc4/distributions/mixture.py
@@ -1,7 +1,15 @@
+"""PyMC4 Distribution of a random variable consisting of a mixture of other
+distributions.
+
+Wraps tfd.Mixture as pm.Mixture
+"""
+import tensorflow as tf
+from tensorflow_probability import distributions as tfd
+
+import pymc4 as pm
 from pymc4.distributions.distribution import Distribution
 
 
-# TODO: Implement this
 class Mixture(Distribution):
     r"""
     Mixture random variable.
@@ -19,7 +27,7 @@ class Mixture(Distribution):
     ----------
     p : array of floats
         p >= 0 and p <= 1
-        the mixture weights, in the form of probabilities
+        the mixture weights, in the form of probabilities, must sum to one.
     distributions : multidimensional PyMC4 distribution (e.g. `pm.Poisson(...)`)
         or iterable of one-dimensional PyMC4 distributions the
         component distributions :math:`f_1, \ldots, f_n`
@@ -27,3 +35,16 @@ class Mixture(Distribution):
 
     def __init__(self, name, p, distributions, **kwargs):
         super().__init__(name, p=p, distributions=distributions, **kwargs)
+
+    @staticmethod
+    def _init_distribution(conditions):
+        p, distributions = conditions["p"], conditions["distributions"]
+        if isinstance(p, pm.Categorical):
+            cat = p._distribution
+        else:
+            cat = tfd.Categorical(probs=p)
+        if isinstance(distributions, list):
+            distributions = [d._distribution for d in distributions]
+        elif isinstance(distributions, Distribution):
+            return
+        return tfd.Mixture(cat=cat, components=distributions)

--- a/pymc4/distributions/mixture.py
+++ b/pymc4/distributions/mixture.py
@@ -4,10 +4,8 @@ distributions.
 Wraps tfd.Mixture as pm.Mixture
 """
 
-import collections.abc
-
-import tensorflow as tf
 from tensorflow_probability import distributions as tfd
+
 from pymc4.distributions.distribution import Distribution
 
 

--- a/pymc4/distributions/mixture.py
+++ b/pymc4/distributions/mixture.py
@@ -96,12 +96,16 @@ class Mixture(Distribution):
                 raise TypeError(
                     "every element in 'distribution' needs to be a pymc4.Distribution object"
                 )
-            distr, mixture = [el._distribution for el in d], tfd.Mixture
+            distr = [el._distribution for el in d]
+            return tfd.Mixture(
+                tfd.Categorical(probs=p, **kwargs), distr, **kwargs, use_static_graph=True
+            )
         # else if 'd' is a pymc distribution with batch_size > 1
         elif isinstance(d, Distribution):
-            distr, mixture = d._distribution, tfd.MixtureSameFamily
+            return tfd.MixtureSameFamily(
+                tfd.Categorical(probs=p, **kwargs), d._distribution, **kwargs
+            )
         else:
             raise TypeError(
                 "'distribution' needs to be a pymc4.Distribution object or a sequence of distributions"
             )
-        return mixture(tfd.Categorical(probs=p, **kwargs), distr, **kwargs)

--- a/pymc4/distributions/mixture.py
+++ b/pymc4/distributions/mixture.py
@@ -5,6 +5,8 @@ Wraps tfd.Mixture as pm.Mixture
 """
 
 import collections
+from typing import Union, Tuple, List
+
 import tensorflow as tf
 from tensorflow_probability import distributions as tfd
 from pymc4.distributions.distribution import Distribution
@@ -75,7 +77,13 @@ class Mixture(Distribution):
     on the right-most axis (to ensure correct parameterization use `validate_args=True`)
     """
 
-    def __init__(self, name: str, p: tf.Tensor, distributions, **kwargs):
+    def __init__(
+        self,
+        name: str,
+        p: tf.Tensor,
+        distributions: Union[Distribution, List[Distribution], Tuple[Distribution]],
+        **kwargs,
+    ):
         super().__init__(name, p=p, distributions=distributions, **kwargs)
 
     @staticmethod

--- a/pymc4/distributions/mixture.py
+++ b/pymc4/distributions/mixture.py
@@ -5,6 +5,7 @@ Wraps tfd.Mixture as pm.Mixture
 """
 
 import collections
+import tensorflow as tf
 from tensorflow_probability import distributions as tfd
 from pymc4.distributions.distribution import Distribution
 
@@ -24,11 +25,11 @@ class Mixture(Distribution):
 
     Parameters
     ----------
-    p : array of floats|tensor
+    p : tf.Tensor
         p >= 0 and p <= 1
         The mixture weights, in the form of probabilities,
         must sum to one on the last (i.e., right-most) axis.
-    distributions : PyMC4 distribution|sequence of PyMC4 distributions
+    distributions : pm.Distribution|sequence of pm.Distribution
         Multi-dimensional PyMC4 distribution (e.g. `pm.Poisson(...)`)
         or iterable of one-dimensional PyMC4 distributions
         :math:`f_1, \ldots, f_n`
@@ -37,12 +38,12 @@ class Mixture(Distribution):
     --------
     Let's define a simple two-component Gaussian mixture:
 
-    >>> import numpy as np
+    >>> import tensorflow as tf
     >>> import pymc4 as pm
     >>> @pm.model
     ... def mixture(dat):
-    ...     p = np.array([0.5, 0.5])
-    ...     m = yield pm.Normal("means", loc=np.array([0.0, 0.0]), scale=1.0)
+    ...     p = tf.constant([0.5, 0.5])
+    ...     m = yield pm.Normal("means", loc=tf.constant([0.0, 0.0]), scale=1.0)
     ...     comps = pm.Normal("comps", m, scale=1.0)
     ...     obs = yield pm.Mixture("mix", p=p, distributions=comps, observed=dat)
     ...     return obs
@@ -52,8 +53,8 @@ class Mixture(Distribution):
 
     >>> @pm.model
     ... def mixture(dat):
-    ...     p = np.array([0.5, 0.5])
-    ...     m = yield pm.Normal("means", loc=np.array([0.0, 0.0]), scale=1.0)
+    ...     p = tf.constant([0.5, 0.5])
+    ...     m = yield pm.Normal("means", loc=tf.constant([0.0, 0.0]), scale=1.0)
     ...     comp1 = pm.Normal("comp1", m[..., 0], scale=1.0)
     ...     comp2 = pm.StudentT("comp2", m[..., 1], scale=1.0, df=3)
     ...     obs = yield pm.Mixture("mix", p=p, distributions=[comp1, comp2], observed=dat)
@@ -63,8 +64,8 @@ class Mixture(Distribution):
 
     >>> @pm.model
     ... def mixture(dat):
-    ...     p = np.array([[0.8, 0.2], [0.4, 0.6], [0.5, 0.5]])
-    ...     m = yield pm.Normal("means", loc=[[0.0, 0.0], [0.0, 0.0], [0.0, 0.0]], scale=1.0)
+    ...     p = tf.constant([[0.8, 0.2], [0.4, 0.6], [0.5, 0.5]])
+    ...     m = yield pm.Normal("means", loc=tf.constant([[0.0, 0.0], [0.0, 0.0], [0.0, 0.0]]), scale=1.0)
     ...     comp1 = pm.Normal("d1", m[..., 0], scale=1.0)
     ...     comp2 = pm.StudentT("d2", m[..., 1], scale=1.0, df=3)
     ...     obs = yield pm.Mixture("mix", p=p, distributions=[comp1, comp2], observed=dat)
@@ -74,7 +75,7 @@ class Mixture(Distribution):
     on the right-most axis (to ensure correct parameterization use `validate_args=True`)
     """
 
-    def __init__(self, name, p, distributions, **kwargs):
+    def __init__(self, name: str, p: tf.Tensor, distributions, **kwargs):
         super().__init__(name, p=p, distributions=distributions, **kwargs)
 
     @staticmethod

--- a/pymc4/distributions/mixture.py
+++ b/pymc4/distributions/mixture.py
@@ -58,6 +58,4 @@ class Mixture(Distribution):
                 # create new tfd distribution with parameter
                 distributions.append(ty(**params))
 
-        return tfd.Mixture(cat=tfd.Categorical(probs=p),
-                           components=distributions,
-                           **kwargs)
+        return tfd.Mixture(cat=tfd.Categorical(probs=p), components=distributions, **kwargs)

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -546,39 +546,3 @@ def test_extra_parameters(tf_seed, distribution_extra_parameters):
     if distribution_name not in ["Flat", "HalfFlat"]:
         # Test that a sample can be drawn using the alternative extra parameters values
         dist.sample()
-
-
-@pytest.fixture(scope="function", ids=str)
-def mixture():
-    @pm.model
-    def mix_a():
-        p = [0.5, 0.5]
-        m = yield pm.Normal("means", loc=[0.0, 0.0], scale=1.0)
-        components = pm.Normal("components", [m[0], m[1]], scale=1.0)
-        obs = yield pm.Mixture("mix", p=p, distributions=components)
-        return obs
-
-    @pm.model
-    def mix_b():
-        p = [0.5, 0.5]
-        m = yield pm.Normal("means", loc=[0.0, 0.0], scale=1.0)
-        comp1 = pm.Normal("comp1", m[0], scale=1.0)
-        comp2 = pm.Normal("comp2", m[1], scale=1.0)
-        obs = yield pm.Mixture("mix", p=p, distributions=[comp1, comp2])
-        return obs
-
-    return {"mix_a": mix_a, "mix_b": mix_b}
-
-
-def test_mixture(mixture):
-    with pytest.raises(TypeError, match=r"list of distributions"):
-        pm.Mixture("mix", p=[0.5, 0.5], distributions="not a distribution")
-    with pytest.raises(TypeError, match=r"every element in 'distribution' "):
-        pm.Mixture(
-            "mix",
-            p=[0.5, 0.5],
-            distributions=[pm.Normal("comp1", loc=0.0, scale=1.0), "not a distribution"],
-        )
-
-    pm.sample(mixture["mix_a"](), 10).posterior["mix_a/means"]
-    pm.sample(mixture["mix_b"](), 10).posterior["mix_b/means"]

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -546,3 +546,39 @@ def test_extra_parameters(tf_seed, distribution_extra_parameters):
     if distribution_name not in ["Flat", "HalfFlat"]:
         # Test that a sample can be drawn using the alternative extra parameters values
         dist.sample()
+
+
+@pytest.fixture(scope="function", ids=str)
+def mixture():
+    @pm.model
+    def mix_a():
+        p = [0.5, 0.5]
+        m = yield pm.Normal("means", loc=[0.0, 0.0], scale=1.0)
+        components = pm.Normal("components", [m[0], m[1]], scale=1.0)
+        obs = yield pm.Mixture("mix", p=p, distributions=components)
+        return obs
+
+    @pm.model
+    def mix_b():
+        p = [0.5, 0.5]
+        m = yield pm.Normal("means", loc=[0.0, 0.0], scale=1.0)
+        comp1 = pm.Normal("comp1", m[0], scale=1.0)
+        comp2 = pm.Normal("comp2", m[1], scale=1.0)
+        obs = yield pm.Mixture("mix", p=p, distributions=[comp1, comp2])
+        return obs
+
+    return {"mix_a": mix_a, "mix_b": mix_b}
+
+
+def test_mixture(mixture):
+    with pytest.raises(TypeError, match=r"list of distributions"):
+        pm.Mixture("mix", p=[0.5, 0.5], distributions="not a distribution")
+    with pytest.raises(TypeError, match=r"every element in 'distribution' "):
+        pm.Mixture(
+            "mix",
+            p=[0.5, 0.5],
+            distributions=[pm.Normal("comp1", loc=0.0, scale=1.0), "not a distribution"],
+        )
+
+    pm.sample(mixture["mix_a"](), 10).posterior["mix_a/means"]
+    pm.sample(mixture["mix_b"](), 10).posterior["mix_b/means"]

--- a/tests/test_mixture.py
+++ b/tests/test_mixture.py
@@ -1,0 +1,95 @@
+"""
+Tests for PyMC4 mixture distribution
+"""
+
+import numpy as np
+import pytest
+import tensorflow_probability as tfp
+
+import pymc4 as pm
+from pymc4.coroutine_model import ModelTemplate
+
+tfd = tfp.distributions
+
+distribution_conditions = {
+    "two_components": {
+        "n": 1,
+        "k": 2,
+        "p": np.array([0.5, 0.5], dtype="float32"),
+        "loc": np.array([0.0, 0.0], dtype="float32"),
+        "scale": 1.0,
+    },
+    "three_components": {
+        "n": 1,
+        "k": 3,
+        "p": np.array([0.5, 0.25, 0.25], dtype="float32"),
+        "loc": np.array([0.0, 0.0, 0.0], dtype="float32"),
+        "scale": 1.0,
+    },
+    "two_components_three_distributions": {
+        "n": 3,
+        "k": 2,
+        "p": np.array([[0.5, 0.5], [0.8, 0.2], [0.7, 0.3]], dtype="float32"),
+        "loc": np.array([[0.0, 0.0], [0.0, 0.0], [0.0, 0.0]], dtype="float32"),
+        "scale": 1.0,
+    },
+    "three_components_three_distributions": {
+        "n": 3,
+        "k": 3,
+        "p": np.array([[0.5, 0.25, 0.25], [0.8, 0.1, 0.1], [0.2, 0.5, 0.3]], dtype="float32"),
+        "loc": np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], dtype="float32"),
+        "scale": 1.0,
+    },
+}
+
+
+@pytest.fixture(scope="function", params=list(distribution_conditions), ids=str)
+def mixture_components(request):
+    par = distribution_conditions[request.param]
+    return par["n"], par["k"], par["p"], par["loc"], par["scale"]
+
+
+def _mixture(k, p, loc, scale, dat):
+    m = yield pm.Normal("means", loc=loc, scale=scale)
+    distributions = [pm.Normal("d" + str(i), loc=m[..., i], scale=scale) for i in range(k)]
+    obs = yield pm.Mixture("mix", p=p, distributions=distributions, validate_args=True, dat=dat)
+    return obs
+
+
+def _mixture_same_family(k, p, loc, scale, dat):
+    m = yield pm.Normal("means", loc=loc, scale=scale)
+    distribution = pm.Normal("d", loc=m, scale=scale)
+    obs = yield pm.Mixture("mix", p=p, distributions=distribution, validate_args=True, dat=dat)
+    return obs
+
+
+@pytest.fixture(scope="function", params=[_mixture, _mixture_same_family], ids=str)
+def mixture(mixture_components, request):
+    n, k, p, loc, scale = mixture_components
+    dat = tfd.Normal(loc=np.zeros(n), scale=1).sample(100).numpy().reshape(-1)
+    model = ModelTemplate(request.param, name="mixture", keep_auxiliary=True, keep_return=True)
+    model = model(k, p, loc, scale, dat)
+    return model
+
+
+def test_wrong_distribution_argument_batched_fails():
+    with pytest.raises(TypeError, match=r"sequence of distributions"):
+        pm.Mixture("mix", p=[0.5, 0.5], distributions=tfd.Normal(0, 1))
+
+
+def test_wrong_distribution_argument_in_list_fails():
+    with pytest.raises(TypeError, match=r"every element in 'distribution' "):
+        pm.Mixture(
+            "mix",
+            p=[0.5, 0.5],
+            distributions=[pm.Normal("comp1", loc=0.0, scale=1.0), "not a distribution"],
+        )
+
+
+def test_prior_predictive(mixture):
+    pm.sample_prior_predictive(mixture, sample_shape=100)
+
+
+def test_posterior_predictive(mixture):
+    trace = pm.sample(mixture, num_samples=100, num_chains=2)
+    pm.sample_posterior_predictive(mixture, trace)

--- a/tests/test_mixture.py
+++ b/tests/test_mixture.py
@@ -96,7 +96,7 @@ def test_wrong_distribution_argument_in_list_fails():
 def test_sampling(mixture, xla_fixture):
     model, n, k = mixture
     if xla_fixture:
-        with pytest.raises(tf.python.framework.errors_impl.InvalidArgumentError):
+        with pytest.raises(tf.errors.InvalidArgumentError):
             pm.sample(model, num_samples=100, num_chains=2, xla=xla_fixture)
     else:
         trace = pm.sample(model, num_samples=100, num_chains=2, xla=xla_fixture)


### PR DESCRIPTION
Hello all,

I've started implementing mixture distributions, in case you're interested. However, there are still some issues:

- the TFP mixture uses latent, discrete indicators and I don't see how one can easily implement marginal mixtures using it,
- the posterior intervals of some parameters are different when I use different implementations and I don't yet understand why that is. More specifically, imagine if I implement the mixture class and a model like this:

```python
class Mixture(Distribution):
    def __init__(self, name, p, distributions, **kwargs):
        super().__init__(name, p=p, distributions=distributions, **kwargs)

    @staticmethod
    def _init_distribution(conditions, **kwargs):
        p, d = conditions["p"], conditions["distributions"]
        distributions = [el._distribution for el in d]
        return tfd.Mixture(cat=tfd.Categorical(probs=p),
                           components=distributions,
                           **kwargs)
@pm.model
def mixture(dat):
    p = [0.5, 0.5]
    m = yield pm.Normal("means", loc=[0.0, 0.0], scale=1.0)
    comp1 = pm.Normal("comp1", m[0], scale=1.0)
    comp2 = pm.Normal("comp2", m[1], scale=1.0)
    obs = yield Mixture("mix", p=p, distributions=[comp1, comp2], observed=dat)
    return obs
```

In this case, I use the underlying TFP distribution of a PyMC distribution and just pass this to `tfd.Mixture`. Hence, I can't use a `yield` statement in the model block for the components (since I need access to the distributions).

Alternatively, I can implement the mixture class like this:

```python
class MixtureManual(Distribution):
    def __init__(self, name, p, distributions, **kwargs):
        super().__init__(name, p=p, distributions=distributions, **kwargs)

    @staticmethod
    def _init_distribution(conditions, **kwargs):
        p, distributions = conditions["p"], conditions["distributions"]
        return tfd.Mixture(cat=tfd.Categorical(probs=p),
                           components=[
                               tfd.Normal(loc=distributions[0], scale=1.0),
                               tfd.Normal(loc=distributions[1], scale=1.0)],
                           **kwargs)

@pm.model
def mixture_manual(dat):
    p = [0.5, 0.5]
    m = yield pm.Normal("means", loc=[0.0, 0.0], scale=1.0)
    comp1 = yield pm.Normal("comp1", m[0], scale=1.0)
    comp2 = yield pm.Normal("comp2", m[1], scale=1.0)
    obs = yield MixtureManual("mix", p=p, distributions=[comp1, comp2], observed=dat)
    return obs
```

In this case, I construct the TFP distributions in the mixture class on the fly.  This version works on `tensors` (*with* `yield` statements in the model block). 

Interestingly, the inferences are not the same. When I create data using a two-component Gaussian mixture with means at `-5` and `5` I get the following posteriors. 

![inf_mix](https://user-images.githubusercontent.com/16086606/84829308-cbf0f200-b027-11ea-9fe0-867ca542cf41.png)

While the means are correctly inferred in the left subfigure, the posteriors on the right 'look more correct'. Am I doing sth wrong here? Here's a [Colab](https://colab.research.google.com/drive/1oyB4lFaqzltgFS3Yz-vDmLQ4AYQxBpfL?usp=sharing) that shows this.

Help would be much appreciated. 

Cheers,
Simon







