### PR TITLE
Fix the MvNormal distribution and add reparametrize to GP

### DIFF
--- a/pymc4/distributions/multivariate.py
+++ b/pymc4/distributions/multivariate.py
@@ -327,7 +327,7 @@ class LKJCholesky(ContinuousDistribution):
 
 class MvNormalCholesky(ContinuousDistribution):
     r"""
-    Multivariate normal random variable.
+    Multivariate normal random variable with cholesky reparametrization.
     
     A Multivariate normal random variable parameterized by a
     lower triangular matrix, i.e., the Cholesky factor L of a covariance matrix
@@ -350,17 +350,17 @@ class MvNormalCholesky(ContinuousDistribution):
         Vector of means.
     scale_tril : array_like
         Lower triangular matrix, such that scale @ scale.T is positive
-        semi-definite
+        semi-definite.
 
     Examples
     --------
-    Define a multivariate normal variable for a given covariance
-    matrix.
+    Define a multivariate normal variable for a given cholesky
+    factor of the full covariance matrix (scale_tril).
 
     >>> covariance_matrix = np.array([[1., 0.5], [0.5, 2]])
     >>> chol_factor = np.linalg.cholesky(covariance_matrix)
     >>> mu = np.zeros(2)
-    >>> vals = pm.MvNormalCholesky('vals', loc=loc, scale=chol_factor)
+    >>> vals = pm.MvNormalCholesky('vals', loc=loc, scale_tril=chol_factor)
     """
 
     def __init__(self, name, loc, scale_tril, **kwargs):

--- a/pymc4/distributions/multivariate.py
+++ b/pymc4/distributions/multivariate.py
@@ -173,19 +173,19 @@ class MvNormal(ContinuousDistribution):
 
     Parameters
     ----------
-    loc : array
+    loc : array_like
         Vector of means.
-    covariance_matrix : array
+    covariance_matrix : array_like
         Covariance matrix.
 
     Examples
     --------
     Define a multivariate normal variable for a given covariance
-    matrix::
+    matrix.
 
-        covariance_matrix = np.array([[1., 0.5], [0.5, 2]])
-        mu = np.zeros(2)
-        vals = pm.MvNormal('vals', loc=loc, covariance_matrix=covariance_matrix, shape=(5, 2))
+    >>> covariance_matrix = np.array([[1., 0.5], [0.5, 2]])
+    >>> mu = np.zeros(2)
+    >>> vals = pm.MvNormal('vals', loc=loc, covariance_matrix=covariance_matrix, shape=(5, 2))
     """
 
     def __init__(self, name, loc, covariance_matrix, **kwargs):
@@ -194,11 +194,9 @@ class MvNormal(ContinuousDistribution):
     @staticmethod
     def _init_distribution(conditions, **kwargs):
         loc, covariance_matrix = conditions["loc"], conditions["covariance_matrix"]
-        try:
-            chol_cov_matrix = tf.linalg.cholesky(covariance_matrix)
-        except tf.errors.InvalidArgumentError:
-            raise ValueError("Cholesky decomposition failed! Check your `covariance_matrix`.")
-        return tfd.MultivariateNormalTriL(loc=loc, scale_tril=chol_cov_matrix, **kwargs)
+        return tfd.MultivariateNormalFullCovariance(
+            loc=loc, covariance_matrix=covariance_matrix, **kwargs
+        )
 
 
 class VonMisesFisher(ContinuousDistribution):
@@ -348,21 +346,21 @@ class MvNormalCholesky(ContinuousDistribution):
 
     Parameters
     ----------
-    loc : array
+    loc : array_like
         Vector of means.
-    scale_tril : array
+    scale_tril : array_like
         Lower triangular matrix, such that scale @ scale.T is positive
         semi-definite
 
     Examples
     --------
     Define a multivariate normal variable for a given covariance
-    matrix::
+    matrix.
 
-        covariance_matrix = np.array([[1., 0.5], [0.5, 2]])
-        chol_factor = np.linalg.cholesky(covariance_matrix)
-        mu = np.zeros(2)
-        vals = pm.MvNormalCholesky('vals', loc=loc, scale=chol_factor)
+    >>> covariance_matrix = np.array([[1., 0.5], [0.5, 2]])
+    >>> chol_factor = np.linalg.cholesky(covariance_matrix)
+    >>> mu = np.zeros(2)
+    >>> vals = pm.MvNormalCholesky('vals', loc=loc, scale=chol_factor)
     """
 
     def __init__(self, name, loc, scale_tril, **kwargs):

--- a/pymc4/gp/gp.py
+++ b/pymc4/gp/gp.py
@@ -90,7 +90,7 @@ class LatentGP(BaseGP):
         r"""Check if there is only one sample point."""
         return X.shape[-(self.feature_ndims + 1)] == 1
 
-    def _build_prior(self, name, X: ArrayLike, **kwargs) -> tuple:
+    def _build_prior(self, name, X: ArrayLike) -> tuple:
         mu = self.mean_fn(X)
         cov = stabilize(self.cov_fn(X, X))
         return mu, cov
@@ -142,7 +142,7 @@ class LatentGP(BaseGP):
         self, name: NameType, X: ArrayLike, *, reparametrize=True, **kwargs
     ) -> ContinuousDistribution:
         r"""
-        Evaluate the GP prior distribution evaluated over the input locations `X`.
+        Evaluate the GP prior distribution over the input locations `X`.
 
         This is the prior probability over the space
         of functions described by its mean and covariance function.
@@ -183,7 +183,7 @@ class LatentGP(BaseGP):
         >>> model = gp_model()
         >>> trace = pm.sample(model, num_samples=100)
         """
-        mu, cov = self._build_prior(name, X, **kwargs)
+        mu, cov = self._build_prior(name, X)
         if self._is_univariate(X):
             return Normal(
                 name=name,

--- a/pymc4/gp/gp.py
+++ b/pymc4/gp/gp.py
@@ -23,12 +23,12 @@ class BaseGP:
         self.cov_fn = cov_fn
 
     def prior(
-        self, name: NameType, X: ArrayLike, *, reparameterize=True, **kwargs
+        self, name: NameType, X: ArrayLike, *, reparametrize=True, **kwargs
     ) -> ContinuousDistribution:
         raise NotImplementedError
 
     def conditional(
-        self, name: NameType, Xnew: ArrayLike, given, *, reparameterize=True, **kwargs
+        self, name: NameType, Xnew: ArrayLike, given, *, reparametrize=True, **kwargs
     ) -> ContinuousDistribution:
         raise NotImplementedError
 
@@ -36,7 +36,7 @@ class BaseGP:
         raise NotImplementedError
 
     def marginal_likelihood(
-        self, name: NameType, X: ArrayLike, *, reparameterize=True, **kwargs
+        self, name: NameType, X: ArrayLike, *, reparametrize=True, **kwargs
     ) -> ContinuousDistribution:
         raise NotImplementedError
 
@@ -139,7 +139,7 @@ class LatentGP(BaseGP):
         return tf.squeeze(mu, axis=[-1]), stabilize(cov)
 
     def prior(
-        self, name: NameType, X: ArrayLike, *, reparameterize=True, **kwargs
+        self, name: NameType, X: ArrayLike, *, reparametrize=True, **kwargs
     ) -> ContinuousDistribution:
         r"""
         Evaluate the GP prior distribution evaluated over the input locations `X`.
@@ -156,7 +156,7 @@ class LatentGP(BaseGP):
             Name of the random variable.
         X : array_like
             Function input values.
-        reparameterize : bool, optional
+        reparametrize : bool, optional
             If ``True``, ``MvNormalCholesky`` distribution is returned instead
             of ``MvNormal``. (default=``True``)
 
@@ -191,13 +191,13 @@ class LatentGP(BaseGP):
                 scale=tf.math.sqrt(tf.squeeze(cov, axis=[-1, -2])),
                 **kwargs,
             )
-        if reparameterize:
+        if reparametrize:
             chol_factor = tf.linalg.cholesky(cov)
             return MvNormalCholesky(name, loc=mu, scale_tril=chol_factor, **kwargs)
         return MvNormal(name, loc=mu, covariance_matrix=cov, **kwargs)
 
     def conditional(
-        self, name: NameType, Xnew: ArrayLike, given: dict, *, reparameterize=True, **kwargs
+        self, name: NameType, Xnew: ArrayLike, given: dict, *, reparametrize=True, **kwargs
     ) -> ContinuousDistribution:
         r"""
         Evaluate the conditional distribution evaluated over new input locations `Xnew`.
@@ -218,7 +218,7 @@ class LatentGP(BaseGP):
             Name of the random variable
         Xnew : array_like
             Function input values.
-        reparameterize : bool, optional
+        reparametrize : bool, optional
             If ``True``, ``MvNormalCholesky`` distribution is returned instead
             of ``MvNormal``. (default=``True``)
         given : dict
@@ -260,7 +260,7 @@ class LatentGP(BaseGP):
                 scale=tf.math.sqrt(tf.squeeze(cov, axis=[-1, -2])),
                 **kwargs,
             )
-        if reparameterize:
+        if reparametrize:
             chol_factor = tf.linalg.cholesky(cov)
             return MvNormalCholesky(name, loc=mu, scale_tril=chol_factor, **kwargs)
         return MvNormal(name=name, loc=mu, covariance_matrix=cov, **kwargs)

--- a/pymc4/gp/gp.py
+++ b/pymc4/gp/gp.py
@@ -22,18 +22,22 @@ class BaseGP:
         self.mean_fn = mean_fn
         self.cov_fn = cov_fn
 
-    def prior(self, name: NameType, X: ArrayLike, *, reparameterize=True, **kwargs) -> ContinuousDistribution:
+    def prior(
+        self, name: NameType, X: ArrayLike, *, reparameterize=True, **kwargs
+    ) -> ContinuousDistribution:
         raise NotImplementedError
 
     def conditional(
-        self, name: NameType, Xnew: ArrayLike, *, reparameterize=True, given, **kwargs
+        self, name: NameType, Xnew: ArrayLike, given, *, reparameterize=True, **kwargs
     ) -> ContinuousDistribution:
         raise NotImplementedError
 
     def predict(self, Xnew: ArrayLike, **kwargs) -> TfTensor:
         raise NotImplementedError
 
-    def marginal_likelihood(self, name: NameType, X: ArrayLike, *, reparameterize=True, **kwargs) -> ContinuousDistribution:
+    def marginal_likelihood(
+        self, name: NameType, X: ArrayLike, *, reparameterize=True, **kwargs
+    ) -> ContinuousDistribution:
         raise NotImplementedError
 
 
@@ -184,7 +188,8 @@ class LatentGP(BaseGP):
             return Normal(
                 name=name,
                 loc=tf.squeeze(mu, axis=[-1]),
-                scale=tf.math.sqrt(tf.squeeze(cov, axis=[-1, -2])) ** kwargs,
+                scale=tf.math.sqrt(tf.squeeze(cov, axis=[-1, -2])),
+                **kwargs,
             )
         if reparameterize:
             chol_factor = tf.linalg.cholesky(cov)
@@ -192,7 +197,7 @@ class LatentGP(BaseGP):
         return MvNormal(name, loc=mu, covariance_matrix=cov, **kwargs)
 
     def conditional(
-        self, name: NameType, Xnew: ArrayLike, *, reparameterize=True, given: dict, **kwargs
+        self, name: NameType, Xnew: ArrayLike, given: dict, *, reparameterize=True, **kwargs
     ) -> ContinuousDistribution:
         r"""
         Evaluate the conditional distribution evaluated over new input locations `Xnew`.
@@ -252,11 +257,10 @@ class LatentGP(BaseGP):
             return Normal(
                 name=name,
                 loc=tf.squeeze(mu, axis=[-1]),
-                scale=tf.math.sqrt(tf.squeeze(cov, axis=[-1, -2])) ** kwargs,
+                scale=tf.math.sqrt(tf.squeeze(cov, axis=[-1, -2])),
+                **kwargs,
             )
         if reparameterize:
             chol_factor = tf.linalg.cholesky(cov)
             return MvNormalCholesky(name, loc=mu, scale_tril=chol_factor, **kwargs)
-        return MvNormal(
-            name=name, loc=mu, covariance_matrix=cov, **kwargs
-        )
+        return MvNormal(name=name, loc=mu, covariance_matrix=cov, **kwargs)

--- a/pymc4/gp/util.py
+++ b/pymc4/gp/util.py
@@ -13,7 +13,7 @@ FreeRV = ArrayLike
 
 
 def stabilize(K, shift=None):
-    r"""Add a diagonal shift to a covarience matrix."""
+    r"""Add a diagonal shift to a covariance matrix."""
     diag = tf.linalg.diag_part(K)
     if shift is None:
         shifted = tf.math.nextafter(diag, np.inf)

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -518,13 +518,6 @@ def test_rvs_test_point_are_valid(tf_seed, distribution_conditions):
     assert not (np.any(np.isinf(logp)) or np.any(np.isnan(logp)))
 
 
-def test_multivariate_normal_cholesky(tf_seed):
-    mean = np.zeros(2)
-    cov = np.array([[-1.0, 0.0], [0.0, -1.0]])
-    with pytest.raises(ValueError, match=r"Cholesky decomposition failed"):
-        pm.MvNormal("x", loc=mean, covariance_matrix=cov)
-
-
 def test_flat_halfflat_broadcast(tf_seed, check_broadcast):
     """Test the error messages returned by Flat and HalfFlat
     distributions for inconsistent sample shapes"""

--- a/tests/test_gp.py
+++ b/tests/test_gp.py
@@ -93,18 +93,3 @@ def test_gp_models_conditional(tf_seed, get_data, get_gp_model):
         assert cond_samples.shape == (3,) + batch_shape
     else:
         assert cond_samples.shape == (3,) + batch_shape + sample_shape
-
-
-def test_gp_invalid_prior(tf_seed):
-    """Test if an error is thrown for invalid model prior"""
-
-    @pm.model
-    def invalid_model(gp, X, X_new):
-        f = gp.prior("f", X)
-        cond = yield gp.conditional("fcond", X_new, given={"X": X, "f": f})
-
-    with pytest.raises(ValueError, match=r"must be a numpy array or tensor"):
-        gp = pm.gp.LatentGP(cov_fn=pm.gp.cov.ExpQuad(1.0, 1.0))
-        X = tf.random.normal((2, 5, 1))
-        X_new = tf.random.normal((2, 2, 1))
-        trace = pm.sample(invalid_model(gp, X, X_new), num_samples=1, burn_in=1, num_chains=1)


### PR DESCRIPTION
This is a quick rework of #269. This or fixes the MvNormal distribution to not reparametrize the normal distribution as ``MvNormalCholesky``. I have also added reparametrize keyword in GP to let the user choose the underlying distribution of the GP.