### PR TITLE
add jitter argument to gp models

### DIFF
--- a/pymc4/gp/util.py
+++ b/pymc4/gp/util.py
@@ -14,10 +14,10 @@ FreeRV = ArrayLike
 
 def stabilize(K, shift=None):
     r"""Add a diagonal shift to a covariance matrix."""
+    K = tf.convert_to_tensor(K)
     diag = tf.linalg.diag_part(K)
     if shift is None:
-        shifted = tf.math.nextafter(diag, np.inf)
-        return tf.linalg.set_diag(K, shifted)
+        shift = 1e-6 if K.dtype == tf.float64 else 1e-4
     return tf.linalg.set_diag(K, diag + shift)
 
 

--- a/tests/test_gp_util.py
+++ b/tests/test_gp_util.py
@@ -10,8 +10,11 @@ doc_string = "Func doc"
 def test_stabilize_default_shift():
     data = tf.constant([[1.0, 2.0], [3.0, 4.0]])
     shifted = pm.gp.util.stabilize(data)
-    expected = tf.constant([[1.0000001, 2.0], [3.0, 4.0000005]])
+    expected = tf.constant([[1.0001, 2.0], [3.0, 4.0001]])
     assert np.allclose(shifted, expected, rtol=1e-18)
+    data = tf.constant([[1.0, 2.0], [3.0, 4.0]], dtype=tf.float64)
+    shifted = pm.gp.util.stabilize(data)
+    expected = tf.constant([[1.000001, 2.0], [3.0, 4.000001]])
 
 
 def test_stabilize():


### PR DESCRIPTION
From a discussion with @Sayam753, cholesky decomposition fails with `tf.float64` datatype when `tf.math.nextafter` is used. This PR removes this from `stabilize` function and instead lets user choose the amount of noise to add via a `jitter` argument in `prior` and `conditional` methods.