### PR TITLE
Added pm.Deterministic class objects to sample state

### DIFF
--- a/pymc4/coroutine_model.py
+++ b/pymc4/coroutine_model.py
@@ -129,9 +129,9 @@ class ModelTemplate:
         >>> print(sorted(state.untransformed_values))
         ['main_model/a/n', 'main_model/n']
 
-        The model return values are stored in ``state.deterministics``
+        The model return values are stored in ``state.deterministics_values``
 
-        >>> print(sorted(list(state.deterministics)))
+        >>> print(sorted(list(state.deterministics_values)))
         ['main_model', 'main_model/a']
 
         Setting :code`keep_return=False` for the nested model we can remove
@@ -143,7 +143,7 @@ class ModelTemplate:
         ...     result = yield nested_model(norm, name="a", keep_return=False)
         ...     return result
         >>> ret, state = pm.evaluate_model(main_model())
-        >>> print(sorted(state.deterministics))
+        >>> print(sorted(state.deterministics_values))
         ['main_model']
 
         We can also observe some variables setting :code:`observed=True` in a distribution

--- a/pymc4/flow/executor.py
+++ b/pymc4/flow/executor.py
@@ -630,6 +630,7 @@ class SamplingExecutor:
                 )
             )
         state.deterministics[scoped_name] = return_value = deterministic.get_value()
+        state.distributions[scoped_name] = deterministic
         return return_value, state
 
     def prepare_model_control_flow(

--- a/pymc4/flow/executor.py
+++ b/pymc4/flow/executor.py
@@ -104,7 +104,7 @@ class SamplingState:
         "distributions",
         "potentials",
         "deterministics",
-        "deterministic_distributions",
+        "deterministic_variables",
     )
 
     def __init__(
@@ -116,7 +116,7 @@ class SamplingState:
         potentials: List[distribution.Potential] = None,
         deterministics: Dict[str, Any] = None,
         posterior_predictives: Optional[Set[str]] = None,
-        deterministic_distributions: Dict[str, distribution.Deterministic] = None,
+        deterministic_variables: Dict[str, distribution.Deterministic] = None,
     ) -> None:
         # verbose __init__
         if transformed_values is None:
@@ -147,10 +147,10 @@ class SamplingState:
             posterior_predictives = set()
         else:
             posterior_predictives = posterior_predictives.copy()
-        if deterministic_distributions is None:
-            deterministic_distributions = dict()
+        if deterministic_variables is None:
+            deterministic_variables = dict()
         else:
-            deterministic_distributions = deterministic_distributions.copy()
+            deterministic_variables = deterministic_variables.copy()
         self.transformed_values = transformed_values
         self.untransformed_values = untransformed_values
         self.observed_values = observed_values
@@ -162,7 +162,7 @@ class SamplingState:
         self.potentials = potentials
         self.deterministics = deterministics
         self.posterior_predictives = posterior_predictives
-        self.deterministic_distributions = deterministic_distributions
+        self.deterministic_variables = deterministic_variables
 
     def collect_log_prob_elemwise(self):
         return itertools.chain(
@@ -183,7 +183,7 @@ class SamplingState:
         observed_values = list(self.observed_values)
         deterministics = list(self.deterministics)
         posterior_predictives = list(self.posterior_predictives)
-        deterministic_distributions = list(self.deterministic_distributions)
+        deterministic_variables = list(self.deterministic_variables)
         # format like dist:name
         distributions = [
             "{}:{}".format(d.__class__.__name__, k) for k, d in self.distributions.items()
@@ -206,7 +206,7 @@ class SamplingState:
             + indent
             + "deterministics: {}\n"
             + indent
-            + "deterministic_distributions: {}\n"
+            + "deterministic_variables: {}\n"
             + indent
             + "posterior_predictives: {})"
         ).format(
@@ -217,7 +217,7 @@ class SamplingState:
             distributions,
             num_potentials,
             deterministics,
-            deterministic_distributions,
+            deterministic_variables,
             posterior_predictives,
         )
 
@@ -247,7 +247,7 @@ class SamplingState:
             potentials=self.potentials,
             deterministics=self.deterministics,
             posterior_predictives=self.posterior_predictives,
-            deterministic_distributions=self.deterministic_distributions,
+            deterministic_variables=self.deterministic_variables,
         )
 
     def as_sampling_state(self) -> "Tuple[SamplingState, List[str]]":
@@ -642,7 +642,7 @@ class SamplingExecutor:
                 )
             )
         state.deterministics[scoped_name] = return_value = deterministic.get_value()
-        state.deterministic_distributions[scoped_name] = deterministic
+        state.deterministic_variables[scoped_name] = deterministic
         return return_value, state
 
     def prepare_model_control_flow(

--- a/pymc4/flow/executor.py
+++ b/pymc4/flow/executor.py
@@ -116,7 +116,7 @@ class SamplingState:
         potentials: List[distribution.Potential] = None,
         deterministics: Dict[str, Any] = None,
         posterior_predictives: Optional[Set[str]] = None,
-        deterministic_distributions: Dic[str, distribution.Deterministic] = None,
+        deterministic_distributions: Dict[str, distribution.Deterministic] = None,
     ) -> None:
         # verbose __init__
         if transformed_values is None:
@@ -246,8 +246,8 @@ class SamplingState:
             distributions=self.distributions,
             potentials=self.potentials,
             deterministics=self.deterministics,
-            deterministic_distributions=self.deterministic_distributions,
             posterior_predictives=self.posterior_predictives,
+            deterministic_distributions=self.deterministic_distributions,
         )
 
     def as_sampling_state(self) -> "Tuple[SamplingState, List[str]]":

--- a/pymc4/flow/executor.py
+++ b/pymc4/flow/executor.py
@@ -147,10 +147,10 @@ class SamplingState:
             posterior_predictives = set()
         else:
             posterior_predictives = posterior_predictives.copy()
-        if deterministics_distributions is None:
+        if deterministic_distributions is None:
             deterministic_distributions = dict()
         else:
-            deterministic_distributions = deterministics_distributions.copy()
+            deterministic_distributions = deterministic_distributions.copy()
         self.transformed_values = transformed_values
         self.untransformed_values = untransformed_values
         self.observed_values = observed_values
@@ -642,7 +642,7 @@ class SamplingExecutor:
                 )
             )
         state.deterministics[scoped_name] = return_value = deterministic.get_value()
-        state.deterministics_distributions[scoped_name] = deterministic
+        state.deterministic_distributions[scoped_name] = deterministic
         return return_value, state
 
     def prepare_model_control_flow(

--- a/pymc4/flow/executor.py
+++ b/pymc4/flow/executor.py
@@ -104,6 +104,7 @@ class SamplingState:
         "distributions",
         "potentials",
         "deterministics",
+        "deterministic_distributions",
     )
 
     def __init__(
@@ -115,6 +116,7 @@ class SamplingState:
         potentials: List[distribution.Potential] = None,
         deterministics: Dict[str, Any] = None,
         posterior_predictives: Optional[Set[str]] = None,
+        deterministic_distributions: Dic[str, distribution.Deterministic] = None,
     ) -> None:
         # verbose __init__
         if transformed_values is None:
@@ -145,6 +147,10 @@ class SamplingState:
             posterior_predictives = set()
         else:
             posterior_predictives = posterior_predictives.copy()
+        if deterministics_distributions is None:
+            deterministic_distributions = dict()
+        else:
+            deterministic_distributions = deterministics_distributions.copy()
         self.transformed_values = transformed_values
         self.untransformed_values = untransformed_values
         self.observed_values = observed_values
@@ -156,6 +162,7 @@ class SamplingState:
         self.potentials = potentials
         self.deterministics = deterministics
         self.posterior_predictives = posterior_predictives
+        self.deterministic_distributions = deterministic_distributions
 
     def collect_log_prob_elemwise(self):
         return itertools.chain(
@@ -176,6 +183,7 @@ class SamplingState:
         observed_values = list(self.observed_values)
         deterministics = list(self.deterministics)
         posterior_predictives = list(self.posterior_predictives)
+        deterministic_distributions = list(self.deterministic_distributions)
         # format like dist:name
         distributions = [
             "{}:{}".format(d.__class__.__name__, k) for k, d in self.distributions.items()
@@ -198,6 +206,8 @@ class SamplingState:
             + indent
             + "deterministics: {}\n"
             + indent
+            + "deterministic_distributions: {}\n"
+            + indent
             + "posterior_predictives: {})"
         ).format(
             self.__class__.__name__,
@@ -207,6 +217,7 @@ class SamplingState:
             distributions,
             num_potentials,
             deterministics,
+            deterministic_distributions,
             posterior_predictives,
         )
 
@@ -235,6 +246,7 @@ class SamplingState:
             distributions=self.distributions,
             potentials=self.potentials,
             deterministics=self.deterministics,
+            deterministic_distributions=self.deterministic_distributions,
             posterior_predictives=self.posterior_predictives,
         )
 
@@ -630,7 +642,7 @@ class SamplingExecutor:
                 )
             )
         state.deterministics[scoped_name] = return_value = deterministic.get_value()
-        state.distributions[scoped_name] = deterministic
+        state.deterministics_distributions[scoped_name] = deterministic
         return return_value, state
 
     def prepare_model_control_flow(

--- a/pymc4/flow/executor.py
+++ b/pymc4/flow/executor.py
@@ -104,7 +104,7 @@ class SamplingState:
         "distributions",
         "potentials",
         "deterministics",
-        "deterministic_variables",
+        "deterministics_values",
     )
 
     def __init__(
@@ -114,9 +114,9 @@ class SamplingState:
         observed_values: Dict[str, Any] = None,
         distributions: Dict[str, distribution.Distribution] = None,
         potentials: List[distribution.Potential] = None,
-        deterministics: Dict[str, Any] = None,
+        deterministics: Dict[str, distribution.Deterministic] = None,
         posterior_predictives: Optional[Set[str]] = None,
-        deterministic_variables: Dict[str, distribution.Deterministic] = None,
+        deterministics_values: Dict[str, Any] = None,
     ) -> None:
         # verbose __init__
         if transformed_values is None:
@@ -147,10 +147,10 @@ class SamplingState:
             posterior_predictives = set()
         else:
             posterior_predictives = posterior_predictives.copy()
-        if deterministic_variables is None:
-            deterministic_variables = dict()
+        if deterministics_values is None:
+            deterministics_values = dict()
         else:
-            deterministic_variables = deterministic_variables.copy()
+            deterministics_values = deterministics_values.copy()
         self.transformed_values = transformed_values
         self.untransformed_values = untransformed_values
         self.observed_values = observed_values
@@ -162,7 +162,7 @@ class SamplingState:
         self.potentials = potentials
         self.deterministics = deterministics
         self.posterior_predictives = posterior_predictives
-        self.deterministic_variables = deterministic_variables
+        self.deterministics_values = deterministics_values
 
     def collect_log_prob_elemwise(self):
         return itertools.chain(
@@ -183,7 +183,7 @@ class SamplingState:
         observed_values = list(self.observed_values)
         deterministics = list(self.deterministics)
         posterior_predictives = list(self.posterior_predictives)
-        deterministic_variables = list(self.deterministic_variables)
+        deterministics_values = list(self.deterministics_values)
         # format like dist:name
         distributions = [
             "{}:{}".format(d.__class__.__name__, k) for k, d in self.distributions.items()
@@ -206,7 +206,7 @@ class SamplingState:
             + indent
             + "deterministics: {}\n"
             + indent
-            + "deterministic_variables: {}\n"
+            + "deterministics_values: {}\n"
             + indent
             + "posterior_predictives: {})"
         ).format(
@@ -217,7 +217,7 @@ class SamplingState:
             distributions,
             num_potentials,
             deterministics,
-            deterministic_variables,
+            deterministics_values,
             posterior_predictives,
         )
 
@@ -641,8 +641,8 @@ class SamplingExecutor:
                     scoped_name
                 )
             )
-        state.deterministics[scoped_name] = return_value = deterministic.get_value()
-        state.deterministic_variables[scoped_name] = deterministic
+        state.deterministics_values[scoped_name] = return_value = deterministic.get_value()
+        state.deterministics[scoped_name] = deterministic
         return return_value, state
 
     def prepare_model_control_flow(
@@ -676,7 +676,7 @@ class SamplingExecutor:
                     "Attempting to create unnamed return variable *after* making a check"
                 )
 
-            state.deterministics[return_name] = return_value
+            state.deterministics_values[return_name] = return_value
         return return_value, state
 
 

--- a/pymc4/flow/executor.py
+++ b/pymc4/flow/executor.py
@@ -247,7 +247,7 @@ class SamplingState:
             potentials=self.potentials,
             deterministics=self.deterministics,
             posterior_predictives=self.posterior_predictives,
-            deterministic_variables=self.deterministic_variables,
+            deterministics_values=self.deterministics_values,
         )
 
     def as_sampling_state(self) -> "Tuple[SamplingState, List[str]]":

--- a/pymc4/flow/executor.py
+++ b/pymc4/flow/executor.py
@@ -571,7 +571,7 @@ class SamplingExecutor:
         if scoped_name is None:
             raise EvaluationError("Attempting to create an anonymous Distribution")
 
-        if scoped_name in state.distributions or scoped_name in state.deterministics:
+        if scoped_name in state.distributions or scoped_name in state.deterministics_values:
             raise EvaluationError(
                 "Attempting to create a duplicate variable {!r}, "
                 "this may happen if you forget to use `pm.name_scope()` when calling same "
@@ -631,7 +631,7 @@ class SamplingExecutor:
         scoped_name = scopes.variable_name(deterministic.name)
         if scoped_name is None:
             raise EvaluationError("Attempting to create an anonymous Deterministic")
-        if scoped_name in state.distributions or scoped_name in state.deterministics:
+        if scoped_name in state.distributions or scoped_name in state.deterministics_values:
             raise EvaluationError(
                 "Attempting to create a duplicate deterministic {!r}, "
                 "this may happen if you forget to use `pm.name_scope()` when calling same "

--- a/pymc4/flow/meta_executor.py
+++ b/pymc4/flow/meta_executor.py
@@ -38,7 +38,7 @@ class MetaSamplingExecutor(TransformedSamplingExecutor):
         if scoped_name is None:
             raise EvaluationError("Attempting to create an anonymous Distribution")
 
-        if scoped_name in state.distributions or scoped_name in state.deterministics:
+        if scoped_name in state.distributions or scoped_name in state.deterministics_values:
             raise EvaluationError(
                 "Attempting to create a duplicate variable {!r}, "
                 "this may happen if you forget to use `pm.name_scope()` when calling same "

--- a/pymc4/forward_sampling.py
+++ b/pymc4/forward_sampling.py
@@ -175,7 +175,7 @@ def sample_prior_predictive(
     # Do a single forward pass to establish the distributions, deterministics and observeds
     _, state = evaluate_meta_model(model, state=state)
     distributions_names = list(state.untransformed_values)
-    deterministic_names = list(state.deterministics)
+    deterministic_names = list(state.deterministics_values)
     observed = None
     traced_observeds: Set[str] = set()
     if sample_from_observed:
@@ -213,7 +213,11 @@ def sample_prior_predictive(
         return tuple(
             state.untransformed_values[k]
             if k in state.untransformed_values
-            else (state.observed_values[k] if k in traced_observeds else state.deterministics[k])
+            else (
+                state.observed_values[k]
+                if k in traced_observeds
+                else state.deterministics_values[k]
+            )
             for k in var_names
         )
 
@@ -314,7 +318,7 @@ def sample_posterior_predictive(
         _, state = evaluate_model_posterior_predictive(
             model, values=values, observed=observed, sample_shape=sample_shape
         )
-        all_values = collections.ChainMap(state.all_values, state.deterministics)
+        all_values = collections.ChainMap(state.all_values, state.deterministics_values)
         if var_names is None:
             var_names = list(state.posterior_predictives)
         output = {k: all_values[k] for k in var_names}
@@ -345,7 +349,7 @@ def sample_posterior_predictive(
     if var_names is None:
         var_names = list(state.posterior_predictives)
     else:
-        defined_variables = set(state.all_values) | set(state.deterministics)
+        defined_variables = set(state.all_values) | set(state.deterministics_values)
         if not set(var_names) <= defined_variables:
             raise KeyError(
                 "The supplied var_names = {} are not defined in the model.\n"
@@ -365,7 +369,7 @@ def sample_posterior_predictive(
         try:
             core_shape = state.all_values[var_name].shape
         except KeyError:
-            if var_name in state.deterministics:
+            if var_name in state.deterministics_values:
                 # Remove the deterministics from the trace
                 del posterior[var_name]
                 continue
@@ -402,7 +406,9 @@ def sample_posterior_predictive(
                     st.untransformed_values[k]
                     if k in st.untransformed_values
                     else (
-                        st.deterministics[k] if k in st.deterministics else st.transformed_values[k]
+                        st.deterministics_values[k]
+                        if k in st.deterministics_values
+                        else st.transformed_values[k]
                     )
                 )
                 for k in var_names

--- a/pymc4/forward_sampling.py
+++ b/pymc4/forward_sampling.py
@@ -203,7 +203,7 @@ def sample_prior_predictive(
     # If we don't have to auto-batch, then we can simply evaluate the model
     if not use_auto_batching:
         _, state = evaluate_model(model, observed=observed, sample_shape=sample_shape)
-        all_values = collections.ChainMap(state.all_values, state.deterministics)
+        all_values = collections.ChainMap(state.all_values, state.deterministics_values)
         return trace_to_arviz(prior_predictive={k: all_values[k].numpy() for k in var_names})
 
     # Setup the function that makes a single draw

--- a/pymc4/inference/sampling.py
+++ b/pymc4/inference/sampling.py
@@ -256,8 +256,10 @@ def build_logp_and_deterministic_functions(
         _, st = flow.evaluate_model_transformed(model, state=st)
         for transformed_name in st.transformed_values:
             untransformed_name = NameParts.from_name(transformed_name).full_untransformed_name
-            st.deterministics[untransformed_name] = st.untransformed_values.pop(untransformed_name)
-        return st.deterministics.values()
+            st.deterministics_values[untransformed_name] = st.untransformed_values.pop(
+                untransformed_name
+            )
+        return st.deterministics_values.values()
 
     return (
         logpfn,

--- a/pymc4/inference/utils.py
+++ b/pymc4/inference/utils.py
@@ -25,7 +25,7 @@ def initialize_sampling_state(
         The list of names of the model's deterministics
     """
     _, state = flow.evaluate_meta_model(model, observed=observed, state=state)
-    deterministic_names = list(state.deterministics)
+    deterministic_names = list(state.deterministics_values)
 
     state, transformed_names = state.as_sampling_state()
     return state, deterministic_names + transformed_names

--- a/pymc4/variational/approximations.py
+++ b/pymc4/variational/approximations.py
@@ -61,10 +61,10 @@ class Approximation(tf.Module):
             _, st = flow.evaluate_model_transformed(self.model, state=st)
             for transformed_name in st.transformed_values:
                 untransformed_name = NameParts.from_name(transformed_name).full_untransformed_name
-                st.deterministics[untransformed_name] = st.untransformed_values.pop(
+                st.deterministics_values[untransformed_name] = st.untransformed_values.pop(
                     untransformed_name
                 )
-            return st.deterministics
+            return st.deterministics_values
 
         def vectorize_function(function):
             def vectorizedfn(*q_samples):

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -220,7 +220,7 @@ def test_complex_model_keep_return():
     _, state = pm.evaluate_model(complex_model())
 
     assert set(state.untransformed_values) == {"complex_model/n", "complex_model/a/n"}
-    assert set(state.deterministics) == {"complex_model", "complex_model/a"}
+    assert set(state.deterministics_values) == {"complex_model", "complex_model/a"}
     assert not state.transformed_values  # we call untransformed executor
     assert not state.observed_values
 
@@ -229,7 +229,7 @@ def test_complex_model_no_keep_return(complex_model):
     _, state = pm.evaluate_model(complex_model())
 
     assert set(state.untransformed_values) == {"complex_model/n", "complex_model/a/n"}
-    assert set(state.deterministics) == {"complex_model/a"}
+    assert set(state.deterministics_values) == {"complex_model/a"}
     assert not state.transformed_values  # we call untransformed executor
     assert not state.observed_values
 
@@ -311,7 +311,7 @@ def test_observed_are_passed_correctly(complex_model_with_observed):
     _, state = pm.evaluate_model(complex_model_with_observed())
 
     assert set(state.untransformed_values) == {"complex_model/n"}
-    assert set(state.deterministics) == {"complex_model/a"}
+    assert set(state.deterministics_values) == {"complex_model/a"}
     assert not state.transformed_values  # we call untransformed executor
     assert set(state.observed_values) == {"complex_model/a/n"}
     assert np.allclose(state.all_values["complex_model/a/n"], np.ones(10))
@@ -323,7 +323,7 @@ def test_observed_are_set_to_none_for_posterior_predictive_correctly(complex_mod
     )
 
     assert set(state.untransformed_values) == {"complex_model/n", "complex_model/a/n"}
-    assert set(state.deterministics) == {"complex_model/a"}
+    assert set(state.deterministics_values) == {"complex_model/a"}
     assert not state.transformed_values  # we call untransformed executor
     assert not state.observed_values
     assert not np.allclose(state.all_values["complex_model/a/n"], np.ones(10))
@@ -441,8 +441,10 @@ def test_sampling_state_clone(deterministics_in_nested_models):
     clone = state.clone()
     assert set(state.all_values) == set(clone.all_values)
     assert all((state.all_values[k] == v for k, v in clone.all_values.items()))
-    assert set(state.deterministics) == set(clone.deterministics)
-    assert all((state.deterministics[k] == v for k, v in clone.deterministics.items()))
+    assert set(state.deterministics_values) == set(clone.deterministics_values)
+    assert all(
+        (state.deterministics_values[k] == v for k, v in clone.deterministics_values.items())
+    )
     assert state.posterior_predictives == clone.posterior_predictives
 
 
@@ -526,7 +528,7 @@ def test_unnamed_return():
         )
 
     _, state = pm.evaluate_model(a_model())
-    assert "a_model" in state.deterministics
+    assert "a_model" in state.deterministics_values
 
     with pytest.raises(pm.flow.executor.EvaluationError) as e:
         pm.evaluate_model(a_model(name=None))
@@ -545,7 +547,7 @@ def test_unnamed_return_2():
         )
 
     _, state = pm.evaluate_model(a_model(name="b_model"))
-    assert "b_model" in state.deterministics
+    assert "b_model" in state.deterministics_values
 
     with pytest.raises(pm.flow.executor.EvaluationError) as e:
         pm.evaluate_model(a_model())
@@ -610,14 +612,14 @@ def test_deterministics(model_with_deterministics):
     model, expected_deterministics, expected_ops, expected_ops_inputs = model_with_deterministics
     _, state = pm.evaluate_model(model())
 
-    assert len(state.deterministics) == len(expected_deterministics)
+    assert len(state.deterministics_values) == len(expected_deterministics)
     assert set(expected_deterministics) <= set(state.deterministics)
     for expected_deterministic, op, op_inputs in zip(
         expected_deterministics, expected_ops, expected_ops_inputs
     ):
         inputs = [v for k, v in state.all_values.items() if k in op_inputs]
         out = op(*inputs)
-        np.testing.assert_allclose(state.deterministics[expected_deterministic], out)
+        np.testing.assert_allclose(state.deterministics_values[expected_deterministic], out)
 
 
 def test_deterministic_with_distribution_name_fails():
@@ -654,10 +656,10 @@ def test_deterministics_in_nested_model(deterministics_in_nested_models):
     _, state = pm.evaluate_model_transformed(model())
     assert set(state.untransformed_values) == expected_untransformed
     assert set(state.transformed_values) == expected_transformed
-    assert set(state.deterministics) == expected_deterministics
+    assert set(state.deterministics_values) == expected_deterministics
     for deterministic, (inputs, op) in deterministic_mapping.items():
         np.testing.assert_allclose(
-            state.deterministics[deterministic],
+            state.deterministics_values[deterministic],
             op(*[state.untransformed_values[i] for i in inputs]),
         )
 
@@ -720,10 +722,10 @@ def test_meta_executor(deterministics_in_nested_models, fixture_batch_shapes):
     _, state = pm.evaluate_meta_model(model(), sample_shape=fixture_batch_shapes)
     assert set(state.untransformed_values) == set(expected_untransformed)
     assert set(state.transformed_values) == set(expected_transformed)
-    assert set(state.deterministics) == set(expected_deterministics)
+    assert set(state.deterministics_values) == set(expected_deterministics)
     for deterministic, (inputs, op) in deterministic_mapping.items():
         np.testing.assert_allclose(
-            state.deterministics[deterministic],
+            state.deterministics_values[deterministic],
             op(*[state.untransformed_values[i] for i in inputs]),
         )
     for rv_name, value in state.untransformed_values.items():

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -613,7 +613,7 @@ def test_deterministics(model_with_deterministics):
     _, state = pm.evaluate_model(model())
 
     assert len(state.deterministics_values) == len(expected_deterministics)
-    assert set(expected_deterministics) <= set(state.deterministics)
+    assert set(expected_deterministics) <= set(state.deterministics_values)
     for expected_deterministic, op, op_inputs in zip(
         expected_deterministics, expected_ops, expected_ops_inputs
     ):

--- a/tests/test_forward_sampling.py
+++ b/tests/test_forward_sampling.py
@@ -260,7 +260,9 @@ def test_posterior_predictive_executor(model_with_observed_fixture):
     assert len(ppc_state.observed_values) == 0
     for var, shape in core_ppc_shapes.items():
         assert (
-            collections.ChainMap(ppc_state.all_values, ppc_state.deterministics)[var].numpy().shape
+            collections.ChainMap(ppc_state.all_values, ppc_state.deterministics_values)[var]
+            .numpy()
+            .shape
             == shape
         )
         if var in observed:


### PR DESCRIPTION
Hi,
I tried to overload the pm.*Distributions* classes to add some extra functionality i.e. add some variables which can be defined for plotting or other purposes later.

For example:
```python
class my_Normal(pm.Normal):
    def __init__(self,*args,**kwargs):
        if "foo" in kwargs:
            self.foo = kwargs.get("foo")
        super().__init__(*args,**kwargs)
#And later access it via
_, state = pm.evaluate_model(model_with_my_Normal)

#Now we can access the foo attribute via
state.distributions["model_name/my_Normal_name"].foo #This Works!
```
This is all nice and works but if we try to apply the same concept to the `pm.Deterministic` class we find that `state.deterministics["model_name/my_Normal_name"]` is a tensor and the object is not added to `state.distributions` as well. That is intended behaviour,  so I added an extra dict in the sampling state for deterministic "distributions", which allows me to do:

```python
class my_Deterministic(pm.Deterministic):
    def __init__(self,*args,**kwargs):
        if "foo" in kwargs:
            self.foo = kwargs.get("foo")
        super().__init__(*args,**kwargs)

_, state = pm.evaluate_model(model_with_my_Deterministic)
state.deterministic_distributions["model_name/my_Deterministic_name"].foo #This works now too!
``` 

This all feels a bit hacky and I'm not too sure if this breaks anything but I found it quite useful. If you think this could be a feature feel free to merge the pull request or change anything you see fit. Otherwise just reject/close the request ;)

Best wishes and keep up the good work,
Sebastian

