### PR TITLE
Remove transformations for Discrete distributions

### DIFF
--- a/pymc4/distributions/discrete.py
+++ b/pymc4/distributions/discrete.py
@@ -5,7 +5,6 @@ from pymc4.distributions.distribution import (
     PositiveDiscreteDistribution,
     BoundedDiscreteDistribution,
 )
-from pymc4.distributions import transforms
 
 __all__ = [
     "Bernoulli",
@@ -356,12 +355,6 @@ class Geometric(BoundedDiscreteDistribution):
 
     # Another example for a wrong type used on the tensorflow side
     _test_value = 2.0  # type: ignore
-
-    def _init_transform(self, transform):
-        if transform is None:
-            return transforms.LowerBound(self.lower_limit())
-        else:
-            return transform
 
     def __init__(self, name, probs, **kwargs):
         super().__init__(name, probs=probs, **kwargs)

--- a/pymc4/distributions/distribution.py
+++ b/pymc4/distributions/distribution.py
@@ -279,12 +279,6 @@ class DiscreteDistribution(Distribution):
 
 
 class BoundedDistribution(Distribution):
-    def _init_transform(self, transform):
-        if transform is None:
-            return transforms.Interval(self.lower_limit(), self.upper_limit())
-        else:
-            return transform
-
     @abc.abstractmethod
     def lower_limit(self):
         raise NotImplementedError
@@ -301,6 +295,12 @@ class BoundedDiscreteDistribution(DiscreteDistribution, BoundedDistribution):
 
 
 class BoundedContinuousDistribution(ContinuousDistribution, BoundedDistribution):
+    def _init_transform(self, transform):
+        if transform is None:
+            return transforms.Interval(self.lower_limit(), self.upper_limit())
+        else:
+            return transform
+
     @property
     def _test_value(self):
         return 0.5 * (self.upper_limit() + self.lower_limit())
@@ -338,12 +338,6 @@ class PositiveContinuousDistribution(BoundedContinuousDistribution):
 
 class PositiveDiscreteDistribution(BoundedDiscreteDistribution):
     _test_value = 1
-
-    def _init_transform(self, transform):
-        if transform is None:
-            return transforms.Log()
-        else:
-            return transform
 
     def lower_limit(self):
         return 0


### PR DESCRIPTION
As per discussions in #306 and PyMC3's [Discrete distribution](https://github.com/pymc-devs/pymc3/blob/bf8f0bcd86bf1985efa2619370786f6d905ed4da/pymc3/distributions/distribution.py#L217-L219), this PR reverts the addition of transformations to Discrete distributions from #289.

cc @junpenglao
